### PR TITLE
refactor: remove i18n any cast

### DIFF
--- a/entrypoints/options/main.tsx
+++ b/entrypoints/options/main.tsx
@@ -5,9 +5,8 @@ function localizeElements() {
   const elements = document.querySelectorAll("[data-i18n]");
   elements.forEach((element) => {
     const key = element.getAttribute("data-i18n");
-    if (key && browser.i18n) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const message = (browser.i18n as any).getMessage(key);
+    if (key && chrome.i18n) {
+      const message = chrome.i18n.getMessage(key);
       if (message) {
         element.textContent = message;
       }


### PR DESCRIPTION
### **User description**
## Summary
- replace untyped `browser.i18n` usage with typed `chrome.i18n` call and drop `any` cast

## Testing
- `yarn compile`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_689963f696d0832b9dc704917f36c5de


___

### **PR Type**
Enhancement


___

### **Description**
- Replace untyped `browser.i18n` with typed `chrome.i18n`

- Remove unnecessary `any` cast and ESLint disable comment


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["browser.i18n (any cast)"] --> B["chrome.i18n (typed)"]
  B --> C["Remove ESLint disable"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tsx</strong><dd><code>Replace untyped i18n with typed chrome API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

entrypoints/options/main.tsx

<ul><li>Replace <code>browser.i18n</code> with <code>chrome.i18n</code> for type safety<br> <li> Remove <code>any</code> cast and ESLint disable comment</ul>


</details>


  </td>
  <td><a href="https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/pull/53/files#diff-c58fbb4532cfb5139d51a43c9efbb67b2a869366386d906cd45ccbd8f88a8f2a">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

