### PR TITLE
Switch from react-swc plugin to react plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@types/react": "^19.0.1",
     "@types/react-dom": "^19.0.2",
     "@vitejs/plugin-react": "^6.0.1",
-    "@vitejs/plugin-react-swc": "^4.3.0",
     "@vitest/coverage-v8": "^4.1.0",
     "@wxt-dev/module-react": "1.2.2",
     "jsdom": "^29.0.1",

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "wxt";
 import tailwindcss from "@tailwindcss/vite";
-import react from "@vitejs/plugin-react-swc";
+import react from "@vitejs/plugin-react";
 
 // See https://wxt.dev/api/config.html
 export default defineConfig({


### PR DESCRIPTION
### Motivation
- Vite started emitting deprecation warnings coming from the SWC-based React plugin (`vite:react-swc`) related to `optimizeDeps.esbuildOptions` and `esbuild`, so the project should use the standard React plugin to avoid those plugin-specific deprecation sources.

### Description
- Replaced the SWC plugin import in `wxt.config.ts` by importing `@vitejs/plugin-react` and kept the plugin usage as `react()` so behavior remains consistent.
- Removed `@vitejs/plugin-react-swc` from `devDependencies` in `package.json` to keep package metadata consistent with the active config.

### Testing
- Ran `yarn compile`, which failed due to the environment Node engine mismatch (`engines.node` requires `>=24`, current environment is `20.19.6`).
- Ran `YARN_IGNORE_ENGINES=1 yarn compile`, which proceeded but failed because project-generated WXT artifacts and some type/dependency resolution (e.g. `.wxt/tsconfig.json`, `vitest` types) are not available in the environment, causing TypeScript errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2039b1518832885829b8a1f190e0b)