### PR TITLE
Add dark-mode styles and color-scheme metadata for options, changelog and theme studio

### DIFF
--- a/assets/changelog.css
+++ b/assets/changelog.css
@@ -18,6 +18,7 @@ body {
   background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
   color: #1a202c;
   min-height: 100vh;
+  color-scheme: light dark;
 }
 
 /* Custom Animations */
@@ -351,20 +352,76 @@ a:focus-visible {
     color: #e2e8f0;
   }
 
+  #changelog-page-shell {
+    background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%) !important;
+  }
+
+  #changelog-hero {
+    background: linear-gradient(135deg, #5b21b6 0%, #1d4ed8 100%) !important;
+    border-color: #4338ca !important;
+  }
+
+  #markdown-container {
+    background: #0f172a !important;
+    border-color: rgba(71, 85, 105, 0.6) !important;
+    box-shadow: 0 20px 45px rgba(2, 6, 23, 0.5) !important;
+  }
+
+  #changelog-card-header {
+    background: linear-gradient(135deg, #1d4ed8 0%, #4f46e5 100%) !important;
+  }
+
   .markdown-content {
-    color: #cbd5e1;
+    color: #cbd5e1 !important;
   }
 
   .markdown-content h1,
   .markdown-content h2,
   .markdown-content h3 {
-    color: #f1f5f9;
+    color: #f1f5f9 !important;
+  }
+
+  .markdown-content h2::before {
+    background: linear-gradient(180deg, #a78bfa, #60a5fa);
+  }
+
+  .markdown-content a {
+    color: #a5b4fc;
+  }
+
+  .markdown-content a:hover {
+    color: #c7d2fe;
+    border-bottom-color: #c7d2fe;
+  }
+
+  .markdown-content blockquote {
+    background: linear-gradient(
+      to right,
+      rgba(76, 29, 149, 0.3),
+      rgba(15, 23, 42, 0.2)
+    );
+    color: #ddd6fe;
+    border-left-color: #a78bfa;
+  }
+
+  .markdown-content pre {
+    background: #020617;
+    border-color: #1e293b;
   }
 
   .markdown-content code {
     background: #2d3748;
     color: #f472b6;
     border-color: #4a5568;
+  }
+
+  #changelog-footer {
+    color: #cbd5e1 !important;
+    border-top-color: #334155 !important;
+  }
+
+  #changelog-footer a {
+    color: #a5b4fc !important;
   }
 
   ::-webkit-scrollbar-track {

--- a/assets/options.css
+++ b/assets/options.css
@@ -1,0 +1,87 @@
+body {
+  color-scheme: light dark;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: linear-gradient(135deg, #020617 0%, #0f172a 100%);
+    color: #e2e8f0;
+  }
+
+  #options-page-shell {
+    background: linear-gradient(135deg, #020617 0%, #0f172a 100%) !important;
+  }
+
+  #options-hero {
+    background: linear-gradient(135deg, #5b21b6 0%, #1d4ed8 100%) !important;
+    border-color: #4338ca !important;
+  }
+
+  #markdown-container,
+  #options-sections > div {
+    background: rgba(15, 23, 42, 0.92) !important;
+    border-color: rgba(71, 85, 105, 0.55) !important;
+    box-shadow: 0 14px 35px rgba(2, 6, 23, 0.45) !important;
+  }
+
+  #options-sections [class*="bg-white"],
+  #options-sections [class*="bg-gray-"],
+  #options-sections [class*="bg-blue-"],
+  #options-sections [class*="bg-indigo-"],
+  #options-sections [class*="bg-yellow-"],
+  #options-sections [class*="bg-orange-"],
+  #options-sections [class*="bg-green-"],
+  #options-sections [class*="bg-purple-"],
+  #add-account-modal [class*="bg-white"],
+  #add-account-modal [class*="bg-gray-"],
+  #add-account-modal [class*="bg-blue-"],
+  #add-account-modal [class*="bg-indigo-"],
+  #add-account-modal [class*="bg-green-"],
+  #add-account-modal [class*="bg-yellow-"],
+  #add-account-modal [class*="bg-purple-"],
+  #add-account-modal [class*="bg-amber-"] {
+    background: rgba(15, 23, 42, 0.9) !important;
+  }
+
+  #options-sections [class*="text-gray-"],
+  #options-sections [class*="text-slate-"],
+  #add-account-modal [class*="text-gray-"],
+  #add-account-modal [class*="text-blue-"],
+  #add-account-modal [class*="text-green-"],
+  #add-account-modal [class*="text-indigo-"],
+  #add-account-modal [class*="text-yellow-"],
+  #add-account-modal [class*="text-purple-"],
+  #add-account-modal [class*="text-amber-"] {
+    color: #cbd5e1 !important;
+  }
+
+  #options-sections [class*="border-gray-"],
+  #options-sections [class*="border-blue-"],
+  #options-sections [class*="border-indigo-"],
+  #options-sections [class*="border-purple-"],
+  #options-sections [class*="border-yellow-"],
+  #options-sections [class*="border-green-"],
+  #options-sections [class*="border-orange-"],
+  #add-account-modal [class*="border-gray-"],
+  #add-account-modal [class*="border-blue-"],
+  #add-account-modal [class*="border-indigo-"],
+  #add-account-modal [class*="border-purple-"],
+  #add-account-modal [class*="border-yellow-"],
+  #add-account-modal [class*="border-green-"],
+  #add-account-modal [class*="border-amber-"] {
+    border-color: rgba(100, 116, 139, 0.5) !important;
+  }
+
+  #options-footer {
+    color: #cbd5e1 !important;
+    border-top-color: #334155 !important;
+  }
+
+  #options-footer a {
+    color: #a5b4fc !important;
+  }
+
+  #add-account-modal {
+    background: rgba(2, 6, 23, 0.78) !important;
+  }
+}

--- a/assets/theme-studio.css
+++ b/assets/theme-studio.css
@@ -1,3 +1,7 @@
+:root {
+  color-scheme: dark light;
+}
+
 .studio-page {
   min-height: 100vh;
   display: grid;

--- a/entrypoints/changelog/index.html
+++ b/entrypoints/changelog/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
     <title>__MSG_changelogPageTitle__</title>
     <link rel="stylesheet" href="~/assets/tailwind.css" />
     <link rel="stylesheet" href="~/assets/markdown.css" />
@@ -15,11 +16,13 @@
 
   <body>
     <div
+      id="changelog-page-shell"
       class="flex flex-col p-4 w-full max-w-4xl mx-auto min-h-screen justify-center bg-gradient-to-br from-purple-100 to-indigo-50"
     >
       <main class="px-6 py-6 w-full">
         <!-- Header Section -->
         <div
+          id="changelog-hero"
           class="text-center mb-8 bg-gradient-to-r from-purple-400 to-indigo-600 p-4 sm:p-8 rounded-lg shadow-lg relative border border-indigo-300"
         >
           <h3
@@ -55,7 +58,10 @@
           id="markdown-container"
           class="mb-6 bg-white rounded-2xl shadow-xl overflow-hidden border border-gray-200/50 hover:shadow-2xl transition-all duration-300"
         >
-          <div class="bg-gradient-to-r from-blue-500 to-indigo-500 px-6 py-4">
+          <div
+            id="changelog-card-header"
+            class="bg-gradient-to-r from-blue-500 to-indigo-500 px-6 py-4"
+          >
             <div class="flex items-center gap-3">
               <div
                 class="bg-white/30 backdrop-blur-sm p-2.5 rounded-xl shadow-md"
@@ -98,6 +104,7 @@
     </div>
 
     <footer
+      id="changelog-footer"
       class="mt-12 text-center text-gray-600 border-t border-gray-200 pt-6"
     >
       <div class="mb-4">

--- a/entrypoints/options/index.html
+++ b/entrypoints/options/index.html
@@ -4,9 +4,11 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="color-scheme" content="light dark" />
   <title>__MSG_optionsPageTitle__</title>
   <link rel="stylesheet" href="~/assets/tailwind.css" />
   <link rel="stylesheet" href="~/assets/markdown.css" />
+  <link rel="stylesheet" href="~/assets/options.css" />
   <link rel="stylesheet" href="~/assets/account-switcher.css" />
   <link rel="stylesheet" href="~/assets/intro-custom.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free/css/all.min.css" />
@@ -25,8 +27,10 @@
 
 <body>
   <div
+    id="options-page-shell"
     class="flex flex-col p-4 w-full max-w-4xl mx-auto min-h-screen justify-center bg-gradient-to-br from-purple-100 to-indigo-50">
     <div
+      id="options-hero"
       class="text-center mb-8 bg-gradient-to-r from-purple-400 to-indigo-600 p-4 sm:p-8 rounded-lg shadow-lg relative border border-indigo-300">
       <h3 class="text-2xl sm:text-4xl font-bold text-white inline-block relative">
         Google Cloud Skills Boost - Helper
@@ -77,7 +81,7 @@
       </div>
     </div>
 
-    <div class="mt-4 space-y-4">
+    <div id="options-sections" class="mt-4 space-y-4">
       <!-- BEGIN - Settings -->
 
       <!-- Account Management Card (moved to top) -->
@@ -351,7 +355,7 @@
       <span class="block sm:inline">Your action was successful!</span>
     </div>
 
-    <footer class="mt-12 text-center text-gray-600 border-t border-gray-200 pt-6">
+    <footer id="options-footer" class="mt-12 text-center text-gray-600 border-t border-gray-200 pt-6">
       <div class="mb-4">
         <a target="_blank" rel="noopener noreferrer"
           href="https://chromewebstore.google.com/detail/google-cloud-skills-boost/lmbhjioadhcoebhgapaidogodllonbgg/?utm_source=webext&utm_medium=options_page"

--- a/entrypoints/theme-studio/index.html
+++ b/entrypoints/theme-studio/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark light" />
     <title>Theme Studio - Google Cloud Skills Boost Helper</title>
     <link rel="stylesheet" href="~/assets/tailwind.css" />
     <link rel="stylesheet" href="~/assets/theme-studio.css" />


### PR DESCRIPTION
### Motivation
- Provide consistent dark-mode appearance across the Options, Changelog and Theme Studio pages and allow browsers to render correct color schemes. 
- Harmonize visual elements (cards, headers, footers, code blocks and scrollbars) to improve readability in dark preferences. 

### Description
- fix #104 
- Added dark-mode rules and tweaks to `assets/changelog.css`, including new selectors and `!important` overrides for `#changelog-page-shell`, `#changelog-hero`, `#markdown-container`, `#changelog-card-header`, `#changelog-footer` and various `.markdown-content` styles. 
- Introduced a new `assets/options.css` file containing dark-mode overrides for the options UI and modal elements and applied `color-scheme: light dark` to the `body`. 
- Updated `assets/theme-studio.css` to add a `:root` `color-scheme` declaration to hint supported schemes. 
- Updated HTML entrypoints to include `meta name="color-scheme"` tags and to link the new stylesheet in `entrypoints/options/index.html`, and added element IDs used by the CSS such as `id="changelog-page-shell"`, `id="changelog-hero"`, `id="changelog-card-header"`, `id="changelog-footer"`, `id="options-page-shell"`, `id="options-hero"`, `id="options-sections"`, and `id="options-footer"`. 

### Testing
- No automated tests were executed for these styling and HTML changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de055aeb2c8328b54f07f103e12183)