### PR TITLE
Add UTM tracking to solution links

### DIFF
--- a/components/uiComponents.ts
+++ b/components/uiComponents.ts
@@ -4,6 +4,7 @@
 
 import StorageService from "../services/storageService";
 import SearchService from "../services/searchService";
+import { addSolutionUtmParams } from "../utils/trackingUrl";
 
 const TELEGRAM_SUPPORT_URL = "https://t.me/eplus_google";
 
@@ -195,16 +196,7 @@ const UIComponents = {
     });
 
     if (url) {
-      // Validate and normalize the URL
-      let safeUrl: string | null = null;
-      try {
-        const parsedUrl = new URL(url, "https://eplus.dev");
-        if (parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:") {
-          safeUrl = parsedUrl.toString();
-        }
-      } catch (e) {
-        // Invalid URL, do not render button
-      }
+      const safeUrl = addSolutionUtmParams(url);
 
       if (safeUrl) {
         // Use the same innerHTML-based insertion as the "No solution" branch

--- a/tests/utils/trackingUrl.test.ts
+++ b/tests/utils/trackingUrl.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { addSolutionUtmParams } from "../../utils/trackingUrl";
+
+describe("addSolutionUtmParams", () => {
+  it("adds extension UTM params to solution URLs", () => {
+    const result = addSolutionUtmParams("https://eplus.dev/lab-solution");
+
+    expect(result).toBe(
+      "https://eplus.dev/lab-solution?utm_source=google-cloud-skill-boost&utm_medium=extension",
+    );
+  });
+
+  it("preserves existing query params and hash fragments", () => {
+    const result = addSolutionUtmParams(
+      "https://eplus.dev/lab-solution?t=123#step-2",
+    );
+
+    expect(result).toBe(
+      "https://eplus.dev/lab-solution?t=123&utm_source=google-cloud-skill-boost&utm_medium=extension#step-2",
+    );
+  });
+
+  it("normalizes relative solution URLs against eplus.dev", () => {
+    const result = addSolutionUtmParams("/lab-solution");
+
+    expect(result).toBe(
+      "https://eplus.dev/lab-solution?utm_source=google-cloud-skill-boost&utm_medium=extension",
+    );
+  });
+
+  it("rejects non-http protocols", () => {
+    expect(addSolutionUtmParams("javascript:alert(1)")).toBeNull();
+  });
+});

--- a/utils/trackingUrl.ts
+++ b/utils/trackingUrl.ts
@@ -1,0 +1,30 @@
+const SOLUTION_UTM_PARAMS = {
+  utm_source: "google-cloud-skill-boost",
+  utm_medium: "extension",
+} as const;
+
+const DEFAULT_SOLUTION_URL_BASE = "https://eplus.dev";
+
+/**
+ * Add extension tracking UTM parameters to a solution URL.
+ *
+ * Existing query parameters (including cache-busting timestamps) and hash
+ * fragments are preserved. UTM values are overwritten so solution clicks from
+ * the extension are consistently attributed.
+ */
+export function addSolutionUtmParams(url: string): string | null {
+  try {
+    const parsedUrl = new URL(url, DEFAULT_SOLUTION_URL_BASE);
+    if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+      return null;
+    }
+
+    Object.entries(SOLUTION_UTM_PARAMS).forEach(([key, value]) => {
+      parsedUrl.searchParams.set(key, value);
+    });
+
+    return parsedUrl.toString();
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
### Motivation
- Ensure solution links opened from the extension are attributed to the extension by adding consistent UTM parameters (`utm_source=google-cloud-skill-boost`, `utm_medium=extension`).
- Preserve any existing query parameters, cache-busting timestamps and hash fragments so link behavior is unchanged except for tracking.

### Description
- Add a reusable helper `addSolutionUtmParams` in `utils/trackingUrl.ts` that appends/overwrites UTM params while validating and normalizing URLs. 
- Use the helper in `components/uiComponents.ts` when rendering solution buttons so the opened solution URL includes extension UTM params. 
- Add unit tests in `tests/utils/trackingUrl.test.ts` covering UTM appending, preservation of existing query/hash, relative URL normalization and rejection of non-HTTP protocols.

### Testing
- Ran `git diff --check` which produced no whitespace/formatting errors. 
- Attempted `yarn test tests/utils/trackingUrl.test.ts --runInBand` but execution was blocked because the environment Node version is `20.20.2` while `package.json` requires `>=24.0.0`. 
- Attempted `yarn --ignore-engines test ...` but the test run failed because `vitest` and other dev dependencies were not available in the environment, so the new unit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22a26197b483288d87d36ed8704968)