### PR TITLE
ci: align GitHub automation with Gmail Alias Toolkit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,16 +2,16 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
     branches: [main, dev]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   ci:
@@ -22,11 +22,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      - name: Validate GitHub Actions workflows
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          set -euo pipefail
+          curl -fsSL \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            -o actionlint.tar.gz
+          echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum --check
+          tar -xzf actionlint.tar.gz actionlint
+          ./actionlint -shellcheck= -pyflakes= -color
+
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
           node-version: 24.x
-          cache: "yarn"
+          cache: yarn
+          cache-dependency-path: yarn.lock
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-scripts --ignore-engines
@@ -34,15 +48,32 @@ jobs:
       - name: Prepare WXT types
         run: yarn wxt prepare
 
-      - name: Type check
-        run: yarn compile
+      - name: Compile TypeScript
+        id: compile
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -o pipefail
+          yarn compile --pretty false 2>&1 | tee compile.log
+
+      - name: Upload TypeScript diagnostics
+        if: steps.compile.outcome == 'failure'
+        uses: actions/upload-artifact@v7
+        with:
+          name: typescript-diagnostics
+          path: compile.log
+          if-no-files-found: error
+
+      - name: Fail on TypeScript errors
+        if: steps.compile.outcome == 'failure'
+        run: exit 1
 
       - name: Run tests with coverage
         run: yarn test:coverage
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v7
         if: success()
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: coverage/

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,31 +1,143 @@
 name: dependabot-auto-merge
-on: pull_request_target
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
 
 permissions:
   pull-requests: write
   contents: write
+  actions: read
+  checks: read
+  statuses: read
 
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'pull_request' &&
+        startsWith(github.event.workflow_run.head_branch, 'dependabot/')
+      }}
+
     steps:
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v3.1.0
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: Auto-merge Dependabot PRs for semver-minor updates
-        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor'}}
-        run: gh pr merge --auto --merge "$PR_URL"
+      - name: Verify bot token
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::EPLUS_BOT_TOKEN is empty. Add it to repository Actions secrets."
+            exit 1
+          fi
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{ secrets.EPLUS_BOT_TOKEN }}
 
-      - name: Auto-merge Dependabot PRs for semver-patch updates
-        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
-        run: gh pr merge --auto --merge "$PR_URL"
+      - name: Verify bot identity
+        run: |
+          BOT_LOGIN="$(gh api user --jq .login)"
+          test "$BOT_LOGIN" = "eplus-bot"
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{ secrets.EPLUS_BOT_TOKEN }}
+
+      - name: Resolve pull request
+        id: pr
+        run: |
+          PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
+
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+            PR_NUMBER="$(gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --state open \
+              --head "$HEAD_BRANCH" \
+              --json number \
+              --jq '.[0].number')"
+          fi
+
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+            echo "::notice::No pull request found for head branch $HEAD_BRANCH."
+            echo "should_merge=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PR_JSON="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+          PR_AUTHOR="$(jq -r '.user.login' <<<"$PR_JSON")"
+          PR_STATE="$(jq -r '.state' <<<"$PR_JSON")"
+          PR_DRAFT="$(jq -r '.draft' <<<"$PR_JSON")"
+          PR_HEAD_REF="$(jq -r '.head.ref' <<<"$PR_JSON")"
+          PR_BASE_REF="$(jq -r '.base.ref' <<<"$PR_JSON")"
+          PR_HEAD_REPO="$(jq -r '.head.repo.full_name' <<<"$PR_JSON")"
+
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+          if [ "$PR_AUTHOR" != "dependabot[bot]" ]; then
+            echo "::notice::Skip PR #$PR_NUMBER because it is not a Dependabot PR."
+            echo "should_merge=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          case "$PR_HEAD_REF" in
+            dependabot/*) ;;
+            *)
+              echo "::notice::Skip PR #$PR_NUMBER because head branch is not dependabot/*."
+              echo "should_merge=false" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
+
+          if [ "$PR_HEAD_REPO" != "$GITHUB_REPOSITORY" ]; then
+            echo "::notice::Skip PR #$PR_NUMBER because the head repository is different."
+            echo "should_merge=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$PR_STATE" != "open" ] || [ "$PR_DRAFT" = "true" ] || [ "$PR_HEAD_REF" = "$PR_BASE_REF" ]; then
+            echo "::notice::Skip PR #$PR_NUMBER because it is not ready to merge."
+            echo "should_merge=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "should_merge=true" >> "$GITHUB_OUTPUT"
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          GH_TOKEN: ${{ secrets.EPLUS_BOT_TOKEN }}
+
+      - name: Wait for pull request checks
+        if: ${{ steps.pr.outputs.should_merge == 'true' }}
+        run: |
+          for attempt in {1..60}; do
+            CHECKS="$(gh pr checks "$PR_NUMBER" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json bucket,name,workflow)"
+
+            FAILING_COUNT="$(jq '[.[] | select(.workflow != env.MERGE_WORKFLOW and (.bucket == "fail" or .bucket == "cancel"))] | length' <<<"$CHECKS")"
+            if [ "$FAILING_COUNT" -gt 0 ]; then
+              jq -r '.[] | select(.workflow != env.MERGE_WORKFLOW and (.bucket == "fail" or .bucket == "cancel")) | "::error::\(.workflow): \(.name) failed"' <<<"$CHECKS"
+              exit 1
+            fi
+
+            PENDING_COUNT="$(jq '[.[] | select(.workflow != env.MERGE_WORKFLOW and .bucket == "pending")] | length' <<<"$CHECKS")"
+            if [ "$PENDING_COUNT" -eq 0 ]; then
+              exit 0
+            fi
+
+            echo "Waiting for $PENDING_COUNT pull request check(s) before merging (attempt $attempt/60)."
+            sleep 10
+          done
+
+          echo "::error::Timed out waiting for pull request checks to finish."
+          exit 1
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          MERGE_WORKFLOW: ${{ github.workflow }}
+          GH_TOKEN: ${{ secrets.EPLUS_BOT_TOKEN }}
+
+      - name: Merge Dependabot pull request and delete branch
+        if: ${{ steps.pr.outputs.should_merge == 'true' }}
+        run: gh pr merge --merge --delete-branch "$PR_NUMBER" --repo "$GITHUB_REPOSITORY"
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          GH_TOKEN: ${{ secrets.EPLUS_BOT_TOKEN }}

--- a/.github/workflows/pr-auto-approve.yml
+++ b/.github/workflows/pr-auto-approve.yml
@@ -1,0 +1,181 @@
+name: pr-auto-approve
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  approve:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
+
+    steps:
+      - name: Verify bot token
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::EPLUS_BOT_TOKEN is empty. Add it to repository Actions secrets."
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.EPLUS_BOT_TOKEN }}
+
+      - name: Verify bot identity
+        run: |
+          BOT_LOGIN="$(gh api user --jq .login)"
+          test "$BOT_LOGIN" = "eplus-bot"
+        env:
+          GH_TOKEN: ${{ secrets.EPLUS_BOT_TOKEN }}
+
+      - name: Resolve pull request
+        id: pr
+        run: |
+          PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
+
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+            PR_NUMBER="$(gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --state open \
+              --head "$HEAD_BRANCH" \
+              --json number \
+              --jq '.[0].number')"
+          fi
+
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+            echo "::notice::No pull request found for head branch $HEAD_BRANCH."
+            echo "should_approve=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PR_JSON="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+          PR_AUTHOR="$(jq -r '.user.login' <<<"$PR_JSON")"
+          PR_STATE="$(jq -r '.state' <<<"$PR_JSON")"
+          PR_DRAFT="$(jq -r '.draft' <<<"$PR_JSON")"
+          BOT_LOGIN="$(gh api user --jq .login)"
+
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+          if [ "$PR_AUTHOR" = "$BOT_LOGIN" ]; then
+            echo "::notice::Skipping PR #$PR_NUMBER because '$BOT_LOGIN' cannot approve its own pull request."
+            echo "should_approve=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$PR_STATE" != "open" ]; then
+            echo "::notice::Skipping PR #$PR_NUMBER because it is not open."
+            echo "should_approve=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$PR_DRAFT" = "true" ]; then
+            echo "::notice::Skipping PR #$PR_NUMBER because it is a draft."
+            echo "should_approve=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "should_approve=true" >> "$GITHUB_OUTPUT"
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          GH_TOKEN: ${{ secrets.EPLUS_BOT_TOKEN }}
+
+      - name: Wait for pull request checks
+        if: ${{ steps.pr.outputs.should_approve == 'true' }}
+        run: |
+          for attempt in {1..60}; do
+            CHECKS="$(gh pr checks "$PR_NUMBER" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json bucket,name,workflow)"
+
+            FAILING_COUNT="$(jq '[.[] | select(.workflow != env.APPROVAL_WORKFLOW and (.bucket == "fail" or .bucket == "cancel"))] | length' <<<"$CHECKS")"
+            if [ "$FAILING_COUNT" -gt 0 ]; then
+              jq -r '.[] | select(.workflow != env.APPROVAL_WORKFLOW and (.bucket == "fail" or .bucket == "cancel")) | "::error::\(.workflow): \(.name) failed"' <<<"$CHECKS"
+              exit 1
+            fi
+
+            PENDING_COUNT="$(jq '[.[] | select(.workflow != env.APPROVAL_WORKFLOW and .bucket == "pending")] | length' <<<"$CHECKS")"
+            if [ "$PENDING_COUNT" -eq 0 ]; then
+              exit 0
+            fi
+
+            echo "Waiting for $PENDING_COUNT pull request check(s) before approving (attempt $attempt/60)."
+            sleep 10
+          done
+
+          echo "::error::Timed out waiting for pull request checks to finish."
+          exit 1
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          APPROVAL_WORKFLOW: ${{ github.workflow }}
+          GH_TOKEN: ${{ secrets.EPLUS_BOT_TOKEN }}
+
+      - name: Approve pull request
+        if: ${{ steps.pr.outputs.should_approve == 'true' }}
+        run: |
+          APPROVED_FOR_HEAD="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
+            --paginate \
+            --jq ".[] | select(.user.login == \"eplus-bot\" and .state == \"APPROVED\" and .commit_id == \"$HEAD_SHA\") | .id" \
+            | tail -n 1)"
+
+          if [ -z "$APPROVED_FOR_HEAD" ]; then
+            gh pr review --approve "$PR_NUMBER" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body "$APPROVAL_REVIEW_BODY"
+          fi
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          APPROVAL_REVIEW_BODY: |
+            Approved by @eplus-bot after all pull request checks passed.
+
+            CI run: ${{ github.event.workflow_run.html_url }}
+          GH_TOKEN: ${{ secrets.EPLUS_BOT_TOKEN }}
+
+      - name: Upsert CI approval comment
+        if: ${{ steps.pr.outputs.should_approve == 'true' }}
+        run: |
+          COMMENT_ID="$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+            --paginate \
+            --jq ".[] | select(.user.login == \"eplus-bot\" and (.body | contains(\"$COMMENT_MARKER\"))) | .id" \
+            | tail -n 1)"
+
+          APPROVAL_COMMENT="$(printf '%s\n' \
+            "$COMMENT_MARKER" \
+            "" \
+            "![CI passed](https://img.shields.io/badge/CI-passed-brightgreen)" \
+            "" \
+            "Approved by @eplus-bot after all pull request checks passed." \
+            "" \
+            "CI updated: $CI_UPDATED_AT" \
+            "CI attempt: #$CI_RUN_ATTEMPT" \
+            "Approval workflow: #$APPROVAL_RUN_NUMBER.$APPROVAL_RUN_ATTEMPT" \
+            "" \
+            "CI run: $CI_RUN_URL")"
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api \
+              --method PATCH \
+              "repos/$GITHUB_REPOSITORY/issues/comments/$COMMENT_ID" \
+              -f body="$APPROVAL_COMMENT"
+          else
+            gh api \
+              --method POST \
+              "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+              -f body="$APPROVAL_COMMENT"
+          fi
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          COMMENT_MARKER: "<!-- eplus-bot-ci-approval -->"
+          CI_UPDATED_AT: ${{ github.event.workflow_run.updated_at }}
+          CI_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          CI_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          APPROVAL_RUN_NUMBER: ${{ github.run_number }}
+          APPROVAL_RUN_ATTEMPT: ${{ github.run_attempt }}
+          GH_TOKEN: ${{ secrets.EPLUS_BOT_TOKEN }}

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -1,0 +1,139 @@
+name: pr-auto-assign
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
+
+    steps:
+      - name: Verify bot token
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::EPLUS_BOT_TOKEN is empty. Add it to repository Actions secrets."
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.EPLUS_BOT_TOKEN }}
+
+      - name: Verify bot identity
+        run: |
+          BOT_LOGIN="$(gh api user --jq .login)"
+          test "$BOT_LOGIN" = "eplus-bot"
+        env:
+          GH_TOKEN: ${{ secrets.EPLUS_BOT_TOKEN }}
+
+      - name: Upsert welcome comment
+        run: |
+          COMMENT_ID="$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+            --paginate \
+            --jq ".[] | select(.user.login == \"eplus-bot\" and (.body | contains(\"$COMMENT_MARKER\"))) | .id" \
+            | tail -n 1)"
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api \
+              --method PATCH \
+              "repos/$GITHUB_REPOSITORY/issues/comments/$COMMENT_ID" \
+              -f body="$WELCOME_COMMENT"
+          else
+            gh api \
+              --method POST \
+              "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+              -f body="$WELCOME_COMMENT"
+          fi
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          COMMENT_MARKER: "<!-- eplus-bot-pr-welcome -->"
+          WELCOME_COMMENT: |
+            <!-- eplus-bot-pr-welcome -->
+
+            Thank you for creating this pull request and helping make the project better.
+
+            We will review or merge it after the required checks pass.
+          GH_TOKEN: ${{ secrets.EPLUS_BOT_TOKEN }}
+
+      - name: Add pull request labels
+        run: |
+          add_label() {
+            local name="$1"
+            local color="$2"
+            local description="$3"
+
+            gh api \
+              --method POST \
+              "repos/$GITHUB_REPOSITORY/labels" \
+              -f name="$name" \
+              -f color="$color" \
+              -f description="$description" >/dev/null 2>&1 || true
+
+            gh api \
+              --method POST \
+              "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels" \
+              -f labels[]="$name" >/dev/null
+          }
+
+          add_label "needs-review" "fbca04" "Pull request is ready for maintainer review"
+
+          CHANGED_FILES="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename')"
+
+          if echo "$CHANGED_FILES" | grep -Eq '^(entrypoints|src|utils|services|models|constants)/'; then
+            add_label "app" "1d76db" "Application or extension source code"
+          fi
+
+          if echo "$CHANGED_FILES" | grep -Eq '^(entrypoints/(popup|options)|src/components|assets|public)/'; then
+            add_label "ui" "c5def5" "User interface or visual changes"
+          fi
+
+          if echo "$CHANGED_FILES" | grep -Eq '^(_locales|public/_locales|src/lib/i18n|.*messages\.json)'; then
+            add_label "i18n" "bfdadc" "Translation or localization changes"
+          fi
+
+          if echo "$CHANGED_FILES" | grep -Eq '(\.test\.|\.spec\.|^tests?/|^vitest\.|testing-library)'; then
+            add_label "tests" "0e8a16" "Test coverage or test tooling changes"
+          fi
+
+          if echo "$CHANGED_FILES" | grep -Eq '^(\.github/|package\.json|yarn\.lock|wxt\.config\.ts|tsconfig|vite\.config|tailwind|postcss)'; then
+            add_label "build-ci" "5319e7" "Build, CI, release, or project configuration"
+          fi
+
+          if echo "$CHANGED_FILES" | grep -Eq '(^README|^CHANGELOG|^INSTALL|^CONTRIBUTING|^docs/|\.md$)'; then
+            add_label "documentation" "0075ca" "Documentation changes"
+          fi
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.EPLUS_BOT_TOKEN }}
+
+      - name: Assign PR author
+        run: |
+          gh api \
+            --method POST \
+            "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/assignees" \
+            -f assignees[]="$PR_AUTHOR" >/dev/null || \
+            echo "::notice::Cannot assign $PR_AUTHOR. The user may not be assignable in this repository."
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          GH_TOKEN: ${{ secrets.EPLUS_BOT_TOKEN }}
+
+      - name: Request eplus-bot review
+        run: |
+          gh api \
+            --method POST \
+            "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/requested_reviewers" \
+            -f reviewers[]="eplus-bot" >/dev/null || \
+            echo "::notice::Cannot request eplus-bot review. It may already be requested or unavailable."
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.EPLUS_BOT_TOKEN }}

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -1,29 +1,32 @@
-name: 🎉 PR closed
+name: PR closed
 
 on:
-    pull_request_target:
-        types:
-            - closed
+  pull_request_target:
+    types: [closed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
-    contents: read
-    pull-requests: write
+  contents: read
+  pull-requests: write
 
 jobs:
-    thank-you:
-        runs-on: ubuntu-latest
-        if: github.event.pull_request.merged == true
+  thank-you:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
 
-        steps:
-            - name: Post Thank You Comment
-              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-              env:
-                  comment: Thanks for helping make **Google Cloud Skills Boost - Helper** better!
-              with:
-                  script: |
-                      github.rest.issues.createComment({
-                        issue_number: context.issue.number,
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        body: process.env.comment
-                      })
+    steps:
+      - name: Post Thank You Comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          comment: Thanks for helping make **Google Cloud Skills Boost - Helper** better!
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: process.env.comment
+            })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,25 @@
-name: "Submit to Web Store"
+name: Submit to Web Store
+
 permissions:
   contents: write
+  pull-requests: write
+  actions: read
+  checks: read
+  statuses: read
 
 on:
   push:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to build and publish
+        required: true
+        type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -16,15 +27,71 @@ jobs:
     name: Build and Release
     runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+      WXT_API_KEY: ${{ secrets.WXT_API_KEY }}
+      WXT_API_URL: ${{ secrets.WXT_API_URL }}
+      WXT_ARCADE_POINT_URL: ${{ secrets.WXT_ARCADE_POINT_URL }}
+      WXT_FIREBASE_API_KEY: ${{ secrets.WXT_FIREBASE_API_KEY }}
+      WXT_FIREBASE_AUTH_DOMAIN: ${{ secrets.WXT_FIREBASE_AUTH_DOMAIN }}
+      WXT_FIREBASE_PROJECT_ID: ${{ secrets.WXT_FIREBASE_PROJECT_ID }}
+      WXT_FIREBASE_STORAGE_BUCKET: ${{ secrets.WXT_FIREBASE_STORAGE_BUCKET }}
+      WXT_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.WXT_FIREBASE_MESSAGING_SENDER_ID }}
+      WXT_FIREBASE_APP_ID: ${{ secrets.WXT_FIREBASE_APP_ID }}
+      WXT_FIREBASE_FETCH_INTERVAL_MS: ${{ secrets.WXT_FIREBASE_FETCH_INTERVAL_MS }}
+      WXT_FIREBASE_FETCH_TIMEOUT_MS: ${{ secrets.WXT_FIREBASE_FETCH_TIMEOUT_MS }}
+      FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }}
+      FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
+      FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
+      CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+      CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+      CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+      CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
 
-      - name: Setup Node.js with Yarn cache
+    steps:
+      - name: Verify release bot identity
+        env:
+          EPLUS_BOT_TOKEN: ${{ secrets.EPLUS_BOT_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${EPLUS_BOT_TOKEN:-}" ]; then
+            echo "::error::EPLUS_BOT_TOKEN is empty."
+            exit 1
+          fi
+
+          BOT_LOGIN="$(GH_TOKEN="$EPLUS_BOT_TOKEN" gh api user --jq .login)"
+
+          if [ "$BOT_LOGIN" != "eplus-bot" ]; then
+            echo "::error::EPLUS_BOT_TOKEN belongs to '$BOT_LOGIN', expected 'eplus-bot'."
+            exit 1
+          fi
+
+      - name: Checkout release tag
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+          token: ${{ secrets.EPLUS_BOT_TOKEN }}
+
+      - name: Validate release tag
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$RELEASE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid release tag: $RELEASE_TAG"
+            exit 1
+          fi
+
+          git rev-parse --verify "refs/tags/$RELEASE_TAG^{commit}" >/dev/null
+
+      - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
           node-version: 24.x
-          cache: "yarn"
+
+      - name: Install Yarn
+        run: npm install --global yarn@1.22.22
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-scripts --ignore-engines
@@ -32,19 +99,10 @@ jobs:
       - name: Prepare WXT types
         run: yarn wxt prepare
 
-      - name: Build the extension
-        env:
-          WXT_API_KEY: ${{ secrets.WXT_API_KEY }}
-          WXT_API_URL: ${{ secrets.WXT_API_URL }}
-          WXT_ARCADE_POINT_URL: ${{ secrets.WXT_ARCADE_POINT_URL }}
-          WXT_FIREBASE_API_KEY: ${{ secrets.WXT_FIREBASE_API_KEY }}
-          WXT_FIREBASE_AUTH_DOMAIN: ${{ secrets.WXT_FIREBASE_AUTH_DOMAIN }}
-          WXT_FIREBASE_PROJECT_ID: ${{ secrets.WXT_FIREBASE_PROJECT_ID }}
-          WXT_FIREBASE_STORAGE_BUCKET: ${{ secrets.WXT_FIREBASE_STORAGE_BUCKET }}
-          WXT_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.WXT_FIREBASE_MESSAGING_SENDER_ID }}
-          WXT_FIREBASE_APP_ID: ${{ secrets.WXT_FIREBASE_APP_ID }}
-          WXT_FIREBASE_FETCH_INTERVAL_MS: ${{ secrets.WXT_FIREBASE_FETCH_INTERVAL_MS }}
-          WXT_FIREBASE_FETCH_TIMEOUT_MS: ${{ secrets.WXT_FIREBASE_FETCH_TIMEOUT_MS }}
+      - name: Run tests
+        run: yarn test
+
+      - name: Build browser packages
         run: |
           yarn zip
           yarn zip:firefox --mv3
@@ -52,42 +110,162 @@ jobs:
           yarn zip -b opera
 
       - name: Verify build outputs
-        run: ls -l .output/*.zip
+        run: |
+          set -euo pipefail
+          ls -lh .output/*.zip
 
-      - name: Update CHANGELOG
+          for browser in chrome firefox edge opera; do
+            if ! find .output -maxdepth 1 -type f -name "*-${browser}.zip" -print -quit | grep -q .; then
+              echo "::error::Missing ${browser} release package."
+              exit 1
+            fi
+          done
+
+      - name: Checkout latest main for changelog
+        run: |
+          set -euo pipefail
+          git reset --hard
+          git fetch origin main --tags
+          git checkout -B main origin/main
+
+      - name: Generate CHANGELOG.md and release notes
         id: changelog
         uses: requarks/changelog-action@v1
         with:
           token: ${{ github.token }}
-          tag: ${{ github.ref_name }}
+          tag: ${{ env.RELEASE_TAG }}
+          writeToFile: true
 
-      - name: Commit CHANGELOG.md
-        uses: stefanzweifel/git-auto-commit-action@v7
-        with:
-          branch: main
-          commit_message: "docs: update CHANGELOG.md for ${{ github.ref_name }} [skip ci]"
-          file_pattern: CHANGELOG.md
+      - name: Generate GitHub release body
+        env:
+          CHANGELOG_NOTES: ${{ steps.changelog.outputs.changes }}
+        run: |
+          set -euo pipefail
+          sed "s/{version}/$RELEASE_TAG/g" INSTALL.md > RELEASE_NOTES.md
+          printf '\n\n---\n\n# Changelog\n\n%s\n' "$CHANGELOG_NOTES" >> RELEASE_NOTES.md
+
+      - name: Create changelog pull request as eplus-bot
+        id: changelog_pr
+        env:
+          GH_TOKEN: ${{ secrets.EPLUS_BOT_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet -- CHANGELOG.md; then
+            echo "No CHANGELOG.md update is required for $RELEASE_TAG."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          BRANCH="chore/changelog-$RELEASE_TAG"
+
+          git config user.name "eplus-bot"
+          git config user.email "157664013+eplus-bot@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git add CHANGELOG.md
+          git commit -m "docs: update CHANGELOG.md for $RELEASE_TAG"
+          git push --force origin "HEAD:refs/heads/$BRANCH"
+
+          PR_NUMBER="$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --head "$BRANCH" \
+            --json number \
+            --jq '.[0].number')"
+
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+            PR_URL="$(gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base main \
+              --head "$BRANCH" \
+              --title "docs: update changelog for $RELEASE_TAG" \
+              --body "Automated CHANGELOG.md update generated from release tag \`$RELEASE_TAG\`.\n\nCreated and merged by @eplus-bot after approval from github-actions[bot] and all required checks pass.")"
+            PR_NUMBER="${PR_URL##*/}"
+          fi
+
+          PR_AUTHOR="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json author --jq .author.login)"
+          if [ "$PR_AUTHOR" != "eplus-bot" ]; then
+            echo "::error::Changelog PR #$PR_NUMBER was created by '$PR_AUTHOR', expected 'eplus-bot'."
+            exit 1
+          fi
+
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for pull request checks
+        if: ${{ steps.changelog_pr.outputs.changed == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.EPLUS_BOT_TOKEN }}
+          PR_NUMBER: ${{ steps.changelog_pr.outputs.number }}
+        run: |
+          set -euo pipefail
+
+          for attempt in {1..90}; do
+            CHECKS="$(gh pr checks "$PR_NUMBER" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json bucket,name,workflow 2>/dev/null || echo '[]')"
+
+            CI_COUNT="$(jq '[.[] | select(.name == "Type Check, Test & Build")] | length' <<<"$CHECKS")"
+            FAILING_COUNT="$(jq '[.[] | select(.bucket == "fail" or .bucket == "cancel")] | length' <<<"$CHECKS")"
+            PENDING_COUNT="$(jq '[.[] | select(.bucket == "pending")] | length' <<<"$CHECKS")"
+
+            if [ "$FAILING_COUNT" -gt 0 ]; then
+              jq -r '.[] | select(.bucket == "fail" or .bucket == "cancel") | "::error::\(.workflow): \(.name) failed"' <<<"$CHECKS"
+              exit 1
+            fi
+
+            if [ "$CI_COUNT" -gt 0 ] && [ "$PENDING_COUNT" -eq 0 ]; then
+              exit 0
+            fi
+
+            echo "Waiting for changelog PR checks (attempt $attempt/90, CI found: $CI_COUNT, pending: $PENDING_COUNT)."
+            sleep 10
+          done
+
+          echo "::error::Timed out waiting for changelog checks."
+          exit 1
+
+      - name: Approve changelog pull request as github-actions[bot]
+        if: ${{ steps.changelog_pr.outputs.changed == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.changelog_pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          gh pr review "$PR_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --approve \
+            --body "Automated approval after all required checks passed."
+
+      - name: Merge changelog pull request as eplus-bot
+        if: ${{ steps.changelog_pr.outputs.changed == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.EPLUS_BOT_TOKEN }}
+          PR_NUMBER: ${{ steps.changelog_pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          gh pr merge "$PR_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --squash \
+            --delete-branch
+
+      - name: Restore release tag workspace
+        run: |
+          set -euo pipefail
+          git reset --hard
+          git checkout --detach "$RELEASE_TAG"
 
       - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v3
         with:
-          name: "v.${{ github.ref_name }}"
-          draft: true
-          generate_release_notes: true
-          body_path: INSTALL.md
+          tag_name: ${{ env.RELEASE_TAG }}
+          name: "v${{ env.RELEASE_TAG }}"
+          body_path: RELEASE_NOTES.md
+          draft: false
+          fail_on_unmatched_files: true
           files: .output/*.zip
 
       - name: Submit to stores
-        if: startsWith(github.ref, 'refs/tags/')
-        env:
-          FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }}
-          FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
-          FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
-          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
-          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
-          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
-          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
         run: |
           yarn wxt submit \
             --chrome-zip .output/*-chrome.zip \


### PR DESCRIPTION
## Summary

Synchronize the repository automation with `ePlus-DEV/gmail-alias-toolkit` while preserving the existing development flow: feature branches merge into `dev`, then `dev` merges into `main`.

## Changes

- run CI for pull requests targeting both `dev` and `main`
- add Actionlint validation and TypeScript diagnostic artifacts
- add automatic PR labels, assignee, welcome comment, and `eplus-bot` review request
- approve normal pull requests with `eplus-bot` only after all checks pass
- replace repository auto-merge dependence for Dependabot with a checked `eplus-bot` merge flow
- update release automation to build from an explicit tag, update `CHANGELOG.md` through a pull request, wait for CI, approve, squash-merge, publish the GitHub release, and submit browser packages
- keep the project-specific WXT/Firebase/store secrets and Yarn 1 workflow

## Required repository configuration

- `EPLUS_BOT_TOKEN` must be available as an Actions secret and belong to `eplus-bot`
- GitHub Actions must be allowed to create and approve pull requests for the automated changelog PR flow

## Validation

The updated CI workflow runs Actionlint before TypeScript, tests, coverage, and extension build.