### PR TITLE
fix: address PR #182 review findings

### DIFF
--- a/entrypoints/options/notificationSettings.ts
+++ b/entrypoints/options/notificationSettings.ts
@@ -1,14 +1,14 @@
 import AccountService from "../../services/accountService";
 import NotificationService from "../../services/notificationService";
 
-function getMessage(key: string, fallback: string): string {
+function getMessage(key: string): string {
   try {
     const lookupMessage = browser.i18n.getMessage as unknown as (
       messageName: string,
     ) => string;
-    return lookupMessage(key) || fallback;
+    return lookupMessage(key) || key;
   } catch {
-    return fallback;
+    return key;
   }
 }
 
@@ -48,19 +48,13 @@ function createNotificationCard(): HTMLElement {
         </div>
         <div>
           <h4 class="text-lg font-bold text-gray-800 mb-2" data-i18n="labelEnableNotifications">
-            ${getMessage("labelEnableNotifications", "Enable push notifications")}
+            ${getMessage("labelEnableNotifications")}
           </h4>
           <p class="text-gray-600 text-sm leading-relaxed" data-i18n="descriptionEnableNotifications">
-            ${getMessage(
-              "descriptionEnableNotifications",
-              "Show browser notifications only when you enable this feature.",
-            )}
+            ${getMessage("descriptionEnableNotifications")}
           </p>
           <p class="text-xs text-gray-500 mt-2" data-i18n="notificationPermissionNote">
-            ${getMessage(
-              "notificationPermissionNote",
-              "Permission will be requested only after you turn this on.",
-            )}
+            ${getMessage("notificationPermissionNote")}
           </p>
         </div>
       </div>
@@ -72,7 +66,7 @@ function createNotificationCard(): HTMLElement {
           <div class="absolute left-1 top-1 w-6 h-6 bg-white rounded-full shadow transform transition-transform duration-200 peer-checked:translate-x-6"></div>
         </label>
         <span id="notification-status" class="text-sm font-medium text-gray-700">
-          ${getMessage("labelDisabled", "disabled")}
+          ${getMessage("labelDisabled")}
         </span>
       </div>
     </div>
@@ -97,12 +91,16 @@ async function syncNotificationToggle() {
   toggle.checked = active;
   if (status) {
     status.textContent = active
-      ? getMessage("labelEnabled", "enabled")
-      : getMessage("labelDisabled", "disabled");
+      ? getMessage("labelEnabled")
+      : getMessage("labelDisabled");
   }
 
   if (enabled && !allowed) {
-    await saveNotificationEnabled(false);
+    try {
+      await saveNotificationEnabled(false);
+    } catch (error) {
+      console.debug("Failed to auto-disable notification setting:", error);
+    }
   }
 }
 
@@ -117,15 +115,9 @@ async function handleNotificationToggle(enabled: boolean) {
       const granted = await NotificationService.requestPermission();
       if (!granted) {
         if (toggle) toggle.checked = false;
-        if (status) status.textContent = getMessage("labelDisabled", "disabled");
+        if (status) status.textContent = getMessage("labelDisabled");
         await saveNotificationEnabled(false);
-        showToast(
-          getMessage(
-            "messageNotificationPermissionDenied",
-            "Notification permission was denied. The feature remains disabled.",
-          ),
-          "error",
-        );
+        showToast(getMessage("messageNotificationPermissionDenied"), "error");
         return;
       }
     }
@@ -133,22 +125,29 @@ async function handleNotificationToggle(enabled: boolean) {
     await saveNotificationEnabled(enabled);
     if (status) {
       status.textContent = enabled
-        ? getMessage("labelEnabled", "enabled")
-        : getMessage("labelDisabled", "disabled");
+        ? getMessage("labelEnabled")
+        : getMessage("labelDisabled");
     }
 
     showToast(
       enabled
-        ? getMessage("messageNotificationsEnabled", "Push notifications enabled")
-        : getMessage("messageNotificationsDisabled", "Push notifications disabled"),
+        ? getMessage("messageNotificationsEnabled")
+        : getMessage("messageNotificationsDisabled"),
       "success",
     );
   } catch (error) {
     console.debug("Failed to update notification setting:", error);
     if (toggle) toggle.checked = false;
-    if (status) status.textContent = getMessage("labelDisabled", "disabled");
-    await saveNotificationEnabled(false);
-    showToast(getMessage("errorSaveSetting", "Failed to save setting"), "error");
+    if (status) status.textContent = getMessage("labelDisabled");
+    try {
+      await saveNotificationEnabled(false);
+    } catch (fallbackError) {
+      console.debug(
+        "Failed to persist disabled notification setting:",
+        fallbackError,
+      );
+    }
+    showToast(getMessage("errorSaveSetting"), "error");
   }
 }
 
@@ -170,8 +169,12 @@ export function initNotificationSettings() {
     "notification-toggle",
   ) as HTMLInputElement | null;
   toggle?.addEventListener("change", () => {
-    handleNotificationToggle(Boolean(toggle.checked));
+    handleNotificationToggle(Boolean(toggle.checked)).catch((error) => {
+      console.debug("Failed to handle notification toggle:", error);
+    });
   });
 
-  syncNotificationToggle();
+  syncNotificationToggle().catch((error) => {
+    console.debug("Failed to sync notification toggle:", error);
+  });
 }

--- a/public/_locales/ar/messages.json
+++ b/public/_locales/ar/messages.json
@@ -893,5 +893,23 @@
   "textViaWaterfall": { "message": "عبر آلية التدرج" },
   "textWaterfallTooltipApplied": { "message": "هذا تقدير يعتمد على نقاطك وأحدث المقاعد المتاحة في المجموعة. يبدو أن فئة نقاطك ممتلئة، لذلك ينتقل التقدير إلى الفئة المتاحة المعروضة هنا. الأهلية النهائية تحددها Google عند تخصيص الجوائز." },
   "textWaterfallTooltipEligible": { "message": "هذا تقدير يعتمد على نقاطك وأحدث المقاعد المتاحة في المجموعة. الأهلية النهائية تحددها Google وفقًا لتخصيص الجوائز بأسبقية الوصول." },
-  "textWaterfallTooltipNext": { "message": "لم تصل بعد إلى فئة الجوائز التالية. يعرض هذا المجموعة المقدّرة التالية وعدد النقاط الإضافية التي تحتاجها." }
+  "textWaterfallTooltipNext": { "message": "لم تصل بعد إلى فئة الجوائز التالية. يعرض هذا المجموعة المقدّرة التالية وعدد النقاط الإضافية التي تحتاجها." },
+  "labelEnableNotifications": {
+    "message": "تفعيل الإشعارات الفورية"
+  },
+  "descriptionEnableNotifications": {
+    "message": "عرض إشعارات المتصفح فقط عند تفعيل هذه الميزة."
+  },
+  "notificationPermissionNote": {
+    "message": "سيتم طلب الإذن فقط بعد تفعيل هذا الخيار."
+  },
+  "messageNotificationPermissionDenied": {
+    "message": "تم رفض إذن الإشعارات. ستبقى الميزة معطلة."
+  },
+  "messageNotificationsEnabled": {
+    "message": "تم تفعيل الإشعارات الفورية"
+  },
+  "messageNotificationsDisabled": {
+    "message": "تم تعطيل الإشعارات الفورية"
+  }
 }

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -893,5 +893,23 @@
   "textViaWaterfall": { "message": "per Waterfall" },
   "textWaterfallTooltipApplied": { "message": "Dies ist eine Schätzung basierend auf deinen Punkten und den neuesten verfügbaren Pool-Plätzen. Deine Punktestufe scheint voll zu sein, daher wird die Schätzung auf die hier angezeigte verfügbare Stufe übertragen. Die endgültige Berechtigung wird durch Googles Preisvergabe entschieden." },
   "textWaterfallTooltipEligible": { "message": "Dies ist eine Schätzung basierend auf deinen Punkten und den neuesten verfügbaren Pool-Plätzen. Die endgültige Berechtigung wird durch Googles Preisvergabe nach dem Prinzip „Wer zuerst kommt, mahlt zuerst“ entschieden." },
-  "textWaterfallTooltipNext": { "message": "Du hast die nächste Preisstufe noch nicht erreicht. Dies zeigt den nächsten geschätzten Pool und wie viele Punkte du noch benötigst." }
+  "textWaterfallTooltipNext": { "message": "Du hast die nächste Preisstufe noch nicht erreicht. Dies zeigt den nächsten geschätzten Pool und wie viele Punkte du noch benötigst." },
+  "labelEnableNotifications": {
+    "message": "Push-Benachrichtigungen aktivieren"
+  },
+  "descriptionEnableNotifications": {
+    "message": "Browser-Benachrichtigungen nur anzeigen, wenn Sie diese Funktion aktivieren."
+  },
+  "notificationPermissionNote": {
+    "message": "Die Berechtigung wird erst angefordert, nachdem Sie diese Option aktiviert haben."
+  },
+  "messageNotificationPermissionDenied": {
+    "message": "Die Benachrichtigungsberechtigung wurde verweigert. Die Funktion bleibt deaktiviert."
+  },
+  "messageNotificationsEnabled": {
+    "message": "Push-Benachrichtigungen aktiviert"
+  },
+  "messageNotificationsDisabled": {
+    "message": "Push-Benachrichtigungen deaktiviert"
+  }
 }

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -913,5 +913,23 @@
   },
   "textWaterfallTooltipNext": {
     "message": "You have not reached the next prize tier yet. This shows the next estimated pool and how many more points you need."
+  },
+  "labelEnableNotifications": {
+    "message": "Enable push notifications"
+  },
+  "descriptionEnableNotifications": {
+    "message": "Show browser notifications only when you enable this feature."
+  },
+  "notificationPermissionNote": {
+    "message": "Permission will be requested only after you turn this on."
+  },
+  "messageNotificationPermissionDenied": {
+    "message": "Notification permission was denied. The feature remains disabled."
+  },
+  "messageNotificationsEnabled": {
+    "message": "Push notifications enabled"
+  },
+  "messageNotificationsDisabled": {
+    "message": "Push notifications disabled"
   }
 }

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -893,5 +893,23 @@
   "textViaWaterfall": { "message": "mediante cascada" },
   "textWaterfallTooltipApplied": { "message": "Esta es una estimación basada en tus puntos y las últimas plazas disponibles en la bolsa. Parece que tu nivel de puntos está lleno, por lo que la estimación baja al nivel disponible que se muestra aquí. La elegibilidad final la decide la asignación de premios de Google." },
   "textWaterfallTooltipEligible": { "message": "Esta es una estimación basada en tus puntos y las últimas plazas disponibles en la bolsa. La elegibilidad final la decide la asignación de premios de Google por orden de llegada." },
-  "textWaterfallTooltipNext": { "message": "Aún no has alcanzado el siguiente nivel de premios. Esto muestra la siguiente bolsa estimada y cuántos puntos más necesitas." }
+  "textWaterfallTooltipNext": { "message": "Aún no has alcanzado el siguiente nivel de premios. Esto muestra la siguiente bolsa estimada y cuántos puntos más necesitas." },
+  "labelEnableNotifications": {
+    "message": "Activar notificaciones push"
+  },
+  "descriptionEnableNotifications": {
+    "message": "Mostrar notificaciones del navegador solo cuando actives esta función."
+  },
+  "notificationPermissionNote": {
+    "message": "El permiso se solicitará solo después de que actives esta opción."
+  },
+  "messageNotificationPermissionDenied": {
+    "message": "Se denegó el permiso de notificaciones. La función permanece desactivada."
+  },
+  "messageNotificationsEnabled": {
+    "message": "Notificaciones push activadas"
+  },
+  "messageNotificationsDisabled": {
+    "message": "Notificaciones push desactivadas"
+  }
 }

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -893,5 +893,23 @@
   "textViaWaterfall": { "message": "via cascade" },
   "textWaterfallTooltipApplied": { "message": "Il s’agit d’une estimation basée sur vos points et les dernières places disponibles dans la réserve. Votre niveau de points semble complet, l’estimation descend donc vers le niveau disponible affiché ici. L’éligibilité finale est décidée par l’attribution des prix de Google." },
   "textWaterfallTooltipEligible": { "message": "Il s’agit d’une estimation basée sur vos points et les dernières places disponibles dans la réserve. L’éligibilité finale est décidée par l’attribution des prix de Google selon le principe du premier arrivé, premier servi." },
-  "textWaterfallTooltipNext": { "message": "Vous n’avez pas encore atteint le prochain niveau de prix. Ceci affiche la prochaine réserve estimée et le nombre de points supplémentaires dont vous avez besoin." }
+  "textWaterfallTooltipNext": { "message": "Vous n’avez pas encore atteint le prochain niveau de prix. Ceci affiche la prochaine réserve estimée et le nombre de points supplémentaires dont vous avez besoin." },
+  "labelEnableNotifications": {
+    "message": "Activer les notifications push"
+  },
+  "descriptionEnableNotifications": {
+    "message": "Afficher les notifications du navigateur uniquement lorsque vous activez cette fonctionnalité."
+  },
+  "notificationPermissionNote": {
+    "message": "L'autorisation ne sera demandée qu'après l'activation de cette option."
+  },
+  "messageNotificationPermissionDenied": {
+    "message": "L'autorisation de notification a été refusée. La fonctionnalité reste désactivée."
+  },
+  "messageNotificationsEnabled": {
+    "message": "Notifications push activées"
+  },
+  "messageNotificationsDisabled": {
+    "message": "Notifications push désactivées"
+  }
 }

--- a/public/_locales/hi/messages.json
+++ b/public/_locales/hi/messages.json
@@ -893,5 +893,23 @@
   "textViaWaterfall": { "message": "वॉटरफॉल के माध्यम से" },
   "textWaterfallTooltipApplied": { "message": "यह आपके पॉइंट्स और नवीनतम उपलब्ध पूल स्लॉट्स के आधार पर एक अनुमान है. आपका पॉइंट टियर भरा हुआ लगता है, इसलिए अनुमान यहाँ दिखाए गए उपलब्ध टियर तक नीचे चला जाता है. अंतिम पात्रता Google के पुरस्कार आवंटन द्वारा तय की जाती है." },
   "textWaterfallTooltipEligible": { "message": "यह आपके पॉइंट्स और नवीनतम उपलब्ध पूल स्लॉट्स के आधार पर एक अनुमान है. अंतिम पात्रता Google के पहले आओ, पहले पाओ पुरस्कार आवंटन द्वारा तय की जाती है." },
-  "textWaterfallTooltipNext": { "message": "आप अभी अगले पुरस्कार टियर तक नहीं पहुँचे हैं. यह अगला अनुमानित पूल और आपको कितने और पॉइंट्स चाहिए, यह दिखाता है." }
+  "textWaterfallTooltipNext": { "message": "आप अभी अगले पुरस्कार टियर तक नहीं पहुँचे हैं. यह अगला अनुमानित पूल और आपको कितने और पॉइंट्स चाहिए, यह दिखाता है." },
+  "labelEnableNotifications": {
+    "message": "पुश सूचनाएँ सक्षम करें"
+  },
+  "descriptionEnableNotifications": {
+    "message": "ब्राउज़र सूचनाएँ केवल तभी दिखाएँ जब आप यह सुविधा सक्षम करें।"
+  },
+  "notificationPermissionNote": {
+    "message": "अनुमति केवल इसे चालू करने के बाद ही मांगी जाएगी।"
+  },
+  "messageNotificationPermissionDenied": {
+    "message": "सूचना अनुमति अस्वीकार कर दी गई। यह सुविधा अक्षम रहेगी।"
+  },
+  "messageNotificationsEnabled": {
+    "message": "पुश सूचनाएँ सक्षम की गईं"
+  },
+  "messageNotificationsDisabled": {
+    "message": "पुश सूचनाएँ अक्षम की गईं"
+  }
 }

--- a/public/_locales/it/messages.json
+++ b/public/_locales/it/messages.json
@@ -893,5 +893,23 @@
   "textViaWaterfall": { "message": "tramite waterfall" },
   "textWaterfallTooltipApplied": { "message": "Questa è una stima basata sui tuoi punti e sugli ultimi slot disponibili nel pool. Il tuo livello di punti sembra pieno, quindi la stima scende al livello disponibile mostrato qui. L’idoneità finale è decisa dall’assegnazione dei premi di Google." },
   "textWaterfallTooltipEligible": { "message": "Questa è una stima basata sui tuoi punti e sugli ultimi slot disponibili nel pool. L’idoneità finale è decisa dall’assegnazione dei premi di Google in ordine di arrivo." },
-  "textWaterfallTooltipNext": { "message": "Non hai ancora raggiunto il livello premio successivo. Questo mostra il prossimo pool stimato e quanti punti ti servono ancora." }
+  "textWaterfallTooltipNext": { "message": "Non hai ancora raggiunto il livello premio successivo. Questo mostra il prossimo pool stimato e quanti punti ti servono ancora." },
+  "labelEnableNotifications": {
+    "message": "Attiva le notifiche push"
+  },
+  "descriptionEnableNotifications": {
+    "message": "Mostra le notifiche del browser solo quando attivi questa funzione."
+  },
+  "notificationPermissionNote": {
+    "message": "L'autorizzazione verrà richiesta solo dopo l'attivazione di questa opzione."
+  },
+  "messageNotificationPermissionDenied": {
+    "message": "L'autorizzazione alle notifiche è stata negata. La funzione rimane disattivata."
+  },
+  "messageNotificationsEnabled": {
+    "message": "Notifiche push attivate"
+  },
+  "messageNotificationsDisabled": {
+    "message": "Notifiche push disattivate"
+  }
 }

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -893,5 +893,23 @@
   "textViaWaterfall": { "message": "ウォーターフォール経由" },
   "textWaterfallTooltipApplied": { "message": "これは、あなたのポイントと最新の利用可能なプール枠に基づく推定です。あなたのポイントティアは満員のように見えるため、推定はここに表示されている利用可能なティアに繰り下がります。最終的な対象資格は Google の賞品割り当てによって決定されます。" },
   "textWaterfallTooltipEligible": { "message": "これは、あなたのポイントと最新の利用可能なプール枠に基づく推定です。最終的な対象資格は、Google の先着順による賞品割り当てによって決定されます。" },
-  "textWaterfallTooltipNext": { "message": "まだ次の賞品ティアに到達していません。ここでは次の推定プールと、あと何ポイント必要かを表示しています。" }
+  "textWaterfallTooltipNext": { "message": "まだ次の賞品ティアに到達していません。ここでは次の推定プールと、あと何ポイント必要かを表示しています。" },
+  "labelEnableNotifications": {
+    "message": "プッシュ通知を有効にする"
+  },
+  "descriptionEnableNotifications": {
+    "message": "この機能を有効にした場合のみブラウザ通知を表示します。"
+  },
+  "notificationPermissionNote": {
+    "message": "権限はこの設定をオンにした後にのみ要求されます。"
+  },
+  "messageNotificationPermissionDenied": {
+    "message": "通知の権限が拒否されました。この機能は無効のままです。"
+  },
+  "messageNotificationsEnabled": {
+    "message": "プッシュ通知が有効になりました"
+  },
+  "messageNotificationsDisabled": {
+    "message": "プッシュ通知が無効になりました"
+  }
 }

--- a/public/_locales/ko/messages.json
+++ b/public/_locales/ko/messages.json
@@ -893,5 +893,23 @@
   "textViaWaterfall": { "message": "워터폴 방식" },
   "textWaterfallTooltipApplied": { "message": "이는 현재 포인트와 최신 사용 가능한 풀 슬롯을 기준으로 한 예상입니다. 현재 포인트 티어가 가득 찬 것으로 보여, 예상 결과가 여기에 표시된 사용 가능한 티어로 내려갑니다. 최종 자격은 Google의 상품 배정에 따라 결정됩니다." },
   "textWaterfallTooltipEligible": { "message": "이는 현재 포인트와 최신 사용 가능한 풀 슬롯을 기준으로 한 예상입니다. 최종 자격은 Google의 선착순 상품 배정에 따라 결정됩니다." },
-  "textWaterfallTooltipNext": { "message": "아직 다음 상품 티어에 도달하지 않았습니다. 다음 예상 풀과 추가로 필요한 포인트 수를 보여줍니다." }
+  "textWaterfallTooltipNext": { "message": "아직 다음 상품 티어에 도달하지 않았습니다. 다음 예상 풀과 추가로 필요한 포인트 수를 보여줍니다." },
+  "labelEnableNotifications": {
+    "message": "푸시 알림 사용"
+  },
+  "descriptionEnableNotifications": {
+    "message": "이 기능을 사용할 때만 브라우저 알림을 표시합니다."
+  },
+  "notificationPermissionNote": {
+    "message": "권한은 이 설정을 켠 후에만 요청됩니다."
+  },
+  "messageNotificationPermissionDenied": {
+    "message": "알림 권한이 거부되었습니다. 이 기능은 비활성화된 상태로 유지됩니다."
+  },
+  "messageNotificationsEnabled": {
+    "message": "푸시 알림이 활성화되었습니다"
+  },
+  "messageNotificationsDisabled": {
+    "message": "푸시 알림이 비활성화되었습니다"
+  }
 }

--- a/public/_locales/pt_BR/messages.json
+++ b/public/_locales/pt_BR/messages.json
@@ -893,5 +893,23 @@
   "textViaWaterfall": { "message": "워터폴 방식" },
   "textWaterfallTooltipApplied": { "message": "이는 현재 포인트와 최신 사용 가능한 풀 슬롯을 기준으로 한 예상입니다. 현재 포인트 티어가 가득 찬 것으로 보여, 예상 결과가 여기에 표시된 사용 가능한 티어로 내려갑니다. 최종 자격은 Google의 상품 배정에 따라 결정됩니다." },
   "textWaterfallTooltipEligible": { "message": "이는 현재 포인트와 최신 사용 가능한 풀 슬롯을 기준으로 한 예상입니다. 최종 자격은 Google의 선착순 상품 배정에 따라 결정됩니다." },
-  "textWaterfallTooltipNext": { "message": "아직 다음 상품 티어에 도달하지 않았습니다. 다음 예상 풀과 추가로 필요한 포인트 수를 보여줍니다." }
+  "textWaterfallTooltipNext": { "message": "아직 다음 상품 티어에 도달하지 않았습니다. 다음 예상 풀과 추가로 필요한 포인트 수를 보여줍니다." },
+  "labelEnableNotifications": {
+    "message": "Ativar notificações push"
+  },
+  "descriptionEnableNotifications": {
+    "message": "Mostrar notificações do navegador apenas quando você ativar este recurso."
+  },
+  "notificationPermissionNote": {
+    "message": "A permissão será solicitada somente depois que você ativar esta opção."
+  },
+  "messageNotificationPermissionDenied": {
+    "message": "A permissão de notificação foi negada. O recurso permanece desativado."
+  },
+  "messageNotificationsEnabled": {
+    "message": "Notificações push ativadas"
+  },
+  "messageNotificationsDisabled": {
+    "message": "Notificações push desativadas"
+  }
 }

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -893,5 +893,23 @@
   "textViaWaterfall": { "message": "через waterfall" },
   "textWaterfallTooltipApplied": { "message": "Это оценка на основе ваших баллов и последних доступных слотов фонда. Похоже, ваш уровень по баллам заполнен, поэтому оценка переносится на доступный уровень, показанный здесь. Итоговое право на приз определяется распределением призов Google." },
   "textWaterfallTooltipEligible": { "message": "Это оценка на основе ваших баллов и последних доступных слотов фонда. Итоговое право на приз определяется распределением призов Google в порядке очереди." },
-  "textWaterfallTooltipNext": { "message": "Вы ещё не достигли следующего призового уровня. Здесь показан следующий оценочный фонд и сколько баллов вам ещё нужно." }
+  "textWaterfallTooltipNext": { "message": "Вы ещё не достигли следующего призового уровня. Здесь показан следующий оценочный фонд и сколько баллов вам ещё нужно." },
+  "labelEnableNotifications": {
+    "message": "Включить push-уведомления"
+  },
+  "descriptionEnableNotifications": {
+    "message": "Показывать уведомления браузера только при включении этой функции."
+  },
+  "notificationPermissionNote": {
+    "message": "Разрешение будет запрошено только после включения этой опции."
+  },
+  "messageNotificationPermissionDenied": {
+    "message": "В разрешении на уведомления отказано. Функция остаётся отключённой."
+  },
+  "messageNotificationsEnabled": {
+    "message": "Push-уведомления включены"
+  },
+  "messageNotificationsDisabled": {
+    "message": "Push-уведомления отключены"
+  }
 }

--- a/public/_locales/vi/messages.json
+++ b/public/_locales/vi/messages.json
@@ -893,5 +893,23 @@
   "textViaWaterfall": { "message": "qua cơ chế waterfall" },
   "textWaterfallTooltipApplied": { "message": "Đây là ước tính dựa trên điểm của bạn và số suất mới nhất còn trong quỹ. Hạng điểm của bạn có vẻ đã đầy, nên ước tính sẽ được chuyển xuống hạng còn suất được hiển thị tại đây. Điều kiện nhận giải cuối cùng do Google quyết định khi phân bổ giải thưởng." },
   "textWaterfallTooltipEligible": { "message": "Đây là ước tính dựa trên điểm của bạn và số suất mới nhất còn trong quỹ. Điều kiện nhận giải cuối cùng do Google quyết định theo cơ chế phân bổ giải thưởng ai đến trước được trước." },
-  "textWaterfallTooltipNext": { "message": "Bạn chưa đạt hạng giải thưởng tiếp theo. Phần này hiển thị quỹ ước tính tiếp theo và số điểm bạn cần thêm." }
+  "textWaterfallTooltipNext": { "message": "Bạn chưa đạt hạng giải thưởng tiếp theo. Phần này hiển thị quỹ ước tính tiếp theo và số điểm bạn cần thêm." },
+  "labelEnableNotifications": {
+    "message": "Bật thông báo đẩy"
+  },
+  "descriptionEnableNotifications": {
+    "message": "Chỉ hiển thị thông báo trình duyệt khi bạn bật tính năng này."
+  },
+  "notificationPermissionNote": {
+    "message": "Quyền sẽ chỉ được yêu cầu sau khi bạn bật tùy chọn này."
+  },
+  "messageNotificationPermissionDenied": {
+    "message": "Quyền thông báo đã bị từ chối. Tính năng vẫn bị tắt."
+  },
+  "messageNotificationsEnabled": {
+    "message": "Đã bật thông báo đẩy"
+  },
+  "messageNotificationsDisabled": {
+    "message": "Đã tắt thông báo đẩy"
+  }
 }

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -893,5 +893,23 @@
   "textViaWaterfall": { "message": "通过瀑布机制" },
   "textWaterfallTooltipApplied": { "message": "这是根据你的积分和最新可用奖池名额得出的预估。你的积分等级似乎已满，因此预估结果会顺延到此处显示的可用等级。最终资格由 Google 的奖品分配结果决定。" },
   "textWaterfallTooltipEligible": { "message": "这是根据你的积分和最新可用奖池名额得出的预估。最终资格由 Google 按先到先得原则进行奖品分配来决定。" },
-  "textWaterfallTooltipNext": { "message": "你尚未达到下一个奖品等级。这里显示下一个预估奖池以及你还需要多少积分。" }
+  "textWaterfallTooltipNext": { "message": "你尚未达到下一个奖品等级。这里显示下一个预估奖池以及你还需要多少积分。" },
+  "labelEnableNotifications": {
+    "message": "启用推送通知"
+  },
+  "descriptionEnableNotifications": {
+    "message": "仅在您启用此功能时显示浏览器通知。"
+  },
+  "notificationPermissionNote": {
+    "message": "只有在您开启此选项后才会请求权限。"
+  },
+  "messageNotificationPermissionDenied": {
+    "message": "通知权限被拒绝。该功能保持禁用状态。"
+  },
+  "messageNotificationsEnabled": {
+    "message": "推送通知已启用"
+  },
+  "messageNotificationsDisabled": {
+    "message": "推送通知已禁用"
+  }
 }

--- a/services/notificationService.ts
+++ b/services/notificationService.ts
@@ -1,3 +1,5 @@
+import AccountService from "./accountService";
+
 const NOTIFICATION_PERMISSION = {
   permissions: ["notifications"],
 } as const;
@@ -26,25 +28,48 @@ async function requestPermission(): Promise<boolean> {
   }
 }
 
+async function isEnabled(): Promise<boolean> {
+  try {
+    const settings = await AccountService.getSettings();
+    return Boolean(settings.enableNotifications);
+  } catch (error) {
+    console.debug("Failed to read notification setting:", error);
+    return false;
+  }
+}
+
+async function canNotify(): Promise<boolean> {
+  const [enabled, allowed] = await Promise.all([isEnabled(), hasPermission()]);
+  return enabled && allowed;
+}
+
 async function create(
   id: string,
   title: string,
   message: string,
-): Promise<void> {
-  const allowed = await hasPermission();
-  if (!allowed) return;
+): Promise<boolean> {
+  const allowed = await canNotify();
+  if (!allowed) return false;
 
-  await browser.notifications.create(id, {
-    type: "basic",
-    iconUrl: browser.runtime.getURL("/icon/128.png"),
-    title,
-    message,
-  });
+  try {
+    await browser.notifications.create(id, {
+      type: "basic",
+      iconUrl: browser.runtime.getURL("/icon/128.png"),
+      title,
+      message,
+    });
+    return true;
+  } catch (error) {
+    console.debug("Failed to create notification:", error);
+    return false;
+  }
 }
 
 const NotificationService = {
   hasPermission,
   requestPermission,
+  isEnabled,
+  canNotify,
   create,
 };
 

--- a/tests/services/notificationService.test.ts
+++ b/tests/services/notificationService.test.ts
@@ -1,5 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import AccountService from "../../services/accountService";
 import NotificationService from "../../services/notificationService";
+
+function mockNotificationSetting(enableNotifications: boolean) {
+  return vi.spyOn(AccountService, "getSettings").mockResolvedValue({
+    enableSearchFeature: true,
+    enableNotifications,
+  });
+}
 
 describe("NotificationService", () => {
   beforeEach(() => {
@@ -18,17 +26,35 @@ describe("NotificationService", () => {
   });
 
   it("does not create a notification without permission", async () => {
+    mockNotificationSetting(true);
     vi.spyOn(browser.permissions, "contains").mockImplementation(
       async () => false as never,
     );
     const createNotificationMock = vi.spyOn(browser.notifications, "create");
 
-    await NotificationService.create("test", "Title", "Message");
+    await expect(
+      NotificationService.create("test", "Title", "Message"),
+    ).resolves.toBe(false);
 
     expect(createNotificationMock).not.toHaveBeenCalled();
   });
 
-  it("creates a notification when permission is granted", async () => {
+  it("does not create a notification when the setting is disabled", async () => {
+    mockNotificationSetting(false);
+    vi.spyOn(browser.permissions, "contains").mockImplementation(
+      async () => true as never,
+    );
+    const createNotificationMock = vi.spyOn(browser.notifications, "create");
+
+    await expect(
+      NotificationService.create("test", "Title", "Message"),
+    ).resolves.toBe(false);
+
+    expect(createNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it("creates a notification when enabled and permission is granted", async () => {
+    mockNotificationSetting(true);
     vi.spyOn(browser.permissions, "contains").mockImplementation(
       async () => true as never,
     );
@@ -36,7 +62,9 @@ describe("NotificationService", () => {
       .spyOn(browser.notifications, "create")
       .mockImplementation(async () => "test" as never);
 
-    await NotificationService.create("test", "Title", "Message");
+    await expect(
+      NotificationService.create("test", "Title", "Message"),
+    ).resolves.toBe(true);
 
     expect(createNotificationMock).toHaveBeenCalledWith(
       "test",
@@ -46,5 +74,19 @@ describe("NotificationService", () => {
         message: "Message",
       }),
     );
+  });
+
+  it("returns false instead of rejecting when notification creation fails", async () => {
+    mockNotificationSetting(true);
+    vi.spyOn(browser.permissions, "contains").mockImplementation(
+      async () => true as never,
+    );
+    vi.spyOn(browser.notifications, "create").mockImplementation(async () => {
+      throw new Error("creation failed");
+    });
+
+    await expect(
+      NotificationService.create("test", "Title", "Message"),
+    ).resolves.toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Addresses the Qodo and CodeRabbit review findings on PR #182:

- Localize all notification UI strings via `messages.json` entries in all 13 locales instead of hardcoded English fallbacks (Qodo #1)
- Guard fire-and-forget calls to `handleNotificationToggle()` and `syncNotificationToggle()` so storage failures cannot surface as unhandled promise rejections (Qodo #2, CodeRabbit)
- Wrap fallback `saveNotificationEnabled(false)` writes in their own try/catch so the error toast is always shown (Qodo #3)
- Make `NotificationService.create()` best-effort: catch creation failures, log at debug level, and return a boolean result (Qodo #4)
- Enforce the `enableNotifications` preference in `NotificationService.create()` and expose `isEnabled()`/`canNotify()` (Qodo #5)
- Extend notification service tests for the preference gate and creation-failure handling

## Test plan

- `yarn compile` — clean
- `yarn test` — 259/259 passing
- `yarn build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEaMUdNWnyXrenzob2c9E6