### PR TITLE
feat: improve account creation UX

### DIFF
--- a/entrypoints/options/accountCreationUX.ts
+++ b/entrypoints/options/accountCreationUX.ts
@@ -95,7 +95,7 @@ function enhanceModal(): void {
   }
 
   input.dataset.uxEnhanced = "true";
-  input.autocomplete = "url";
+  input.setAttribute("autocomplete", "url");
   input.inputMode = "url";
   input.spellcheck = false;
   input.placeholder = PROFILE_URL_EXAMPLE;

--- a/entrypoints/options/accountCreationUX.ts
+++ b/entrypoints/options/accountCreationUX.ts
@@ -3,7 +3,9 @@ import ArcadeApiService from "../../services/arcadeApiService";
 const PROFILE_URL_EXAMPLE =
   "https://www.skills.google/public_profiles/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 
-function getMessage(key: string, fallback: string): string {
+type MessageKey = Parameters<typeof browser.i18n.getMessage>[0];
+
+function getMessage(key: MessageKey, fallback: string): string {
   try {
     return browser.i18n.getMessage(key) || fallback;
   } catch {
@@ -53,19 +55,19 @@ function updateInputState(
 
   if (isEmpty) {
     helper.textContent = getMessage(
-      "accountCreationPasteHint",
+      "accountCreationPasteHint" as MessageKey,
       `Paste your public profile URL, for example: ${PROFILE_URL_EXAMPLE}`,
     );
     helper.className = "mt-2 text-xs text-gray-500";
   } else if (isValid) {
     helper.textContent = getMessage(
-      "accountCreationUrlReady",
+      "accountCreationUrlReady" as MessageKey,
       "Profile URL looks valid. Press Enter or select Create account.",
     );
     helper.className = "mt-2 text-xs text-emerald-700";
   } else {
     helper.textContent = getMessage(
-      "errorInvalidProfileUrl",
+      "errorInvalidProfileUrl" as MessageKey,
       "Enter a valid Google Cloud Skills Boost public profile URL.",
     );
     helper.className = "mt-2 text-xs text-red-600";
@@ -120,7 +122,7 @@ function enhanceModal(): void {
     setButtonState(button, true, true);
     button.setAttribute("aria-busy", "true");
     helper.textContent = getMessage(
-      "accountCreationCheckingProfile",
+      "accountCreationCheckingProfile" as MessageKey,
       "Checking profile and creating account…",
     );
     helper.className = "mt-2 text-xs text-indigo-700";
@@ -133,7 +135,10 @@ function enhanceModal(): void {
       updateInputState(input, button, helper);
     }
 
-    if (nickname && !nickname.closest("#step-add-nickname")?.classList.contains("hidden")) {
+    if (
+      nickname &&
+      !nickname.closest("#step-add-nickname")?.classList.contains("hidden")
+    ) {
       (nickname as HTMLInputElement).focus();
     }
   });

--- a/entrypoints/options/accountCreationUX.ts
+++ b/entrypoints/options/accountCreationUX.ts
@@ -88,6 +88,7 @@ function enhanceModal(): void {
   ) as HTMLButtonElement | null;
   const loading = document.getElementById("loading-profile");
   const errorProfile = document.getElementById("error-profile");
+  const errorMessage = document.getElementById("profile-error-message");
   const nickname = document.getElementById("account-nickname-input");
 
   if (!modal || !input || !button || input.dataset.uxEnhanced === "true") {
@@ -136,6 +137,17 @@ function enhanceModal(): void {
 
   const syncAsyncState = (): void => {
     const isLoading = Boolean(loading && !loading.classList.contains("hidden"));
+    const isErrorVisible = Boolean(
+      errorProfile && !errorProfile.classList.contains("hidden"),
+    );
+
+    if (
+      isErrorVisible &&
+      errorMessage?.textContent?.trim() ===
+        getMessage("errorUnableGetUserName").trim()
+    ) {
+      errorMessage.textContent = getMessage("errorInvalidProfileUrl");
+    }
 
     if (isLoading) {
       setBusyState(button, helper);

--- a/entrypoints/options/accountCreationUX.ts
+++ b/entrypoints/options/accountCreationUX.ts
@@ -5,12 +5,8 @@ const PROFILE_URL_EXAMPLE =
 
 type MessageKey = Parameters<typeof browser.i18n.getMessage>[0];
 
-function getMessage(key: MessageKey, fallback: string): string {
-  try {
-    return browser.i18n.getMessage(key) || fallback;
-  } catch {
-    return fallback;
-  }
+function getMessage(key: MessageKey): string {
+  return browser.i18n.getMessage(key);
 }
 
 function ensureHelper(input: HTMLInputElement): HTMLElement {
@@ -37,6 +33,12 @@ function setButtonState(
   button.classList.toggle("opacity-60", !enabled || busy);
   button.classList.toggle("cursor-not-allowed", !enabled || busy);
   button.classList.toggle("cursor-pointer", enabled && !busy);
+
+  if (busy) {
+    button.setAttribute("aria-busy", "true");
+  } else {
+    button.removeAttribute("aria-busy");
+  }
 }
 
 function updateInputState(
@@ -54,26 +56,26 @@ function updateInputState(
   input.setAttribute("aria-invalid", String(!isEmpty && !isValid));
 
   if (isEmpty) {
-    helper.textContent = getMessage(
-      "accountCreationPasteHint" as MessageKey,
-      `Paste your public profile URL, for example: ${PROFILE_URL_EXAMPLE}`,
-    );
+    helper.textContent = "";
     helper.className = "mt-2 text-xs text-gray-500";
   } else if (isValid) {
-    helper.textContent = getMessage(
-      "accountCreationUrlReady" as MessageKey,
-      "Profile URL looks valid. Press Enter or select Create account.",
-    );
+    helper.textContent = getMessage("labelAddAccount");
     helper.className = "mt-2 text-xs text-emerald-700";
   } else {
-    helper.textContent = getMessage(
-      "errorInvalidProfileUrl" as MessageKey,
-      "Enter a valid Google Cloud Skills Boost public profile URL.",
-    );
+    helper.textContent = getMessage("errorInvalidProfileUrl");
     helper.className = "mt-2 text-xs text-red-600";
   }
 
   setButtonState(button, isValid);
+}
+
+function setBusyState(
+  button: HTMLButtonElement,
+  helper: HTMLElement,
+): void {
+  setButtonState(button, true, true);
+  helper.textContent = getMessage("labelAdding");
+  helper.className = "mt-2 text-xs text-indigo-700";
 }
 
 function enhanceModal(): void {
@@ -85,6 +87,7 @@ function enhanceModal(): void {
     "create-account-btn",
   ) as HTMLButtonElement | null;
   const loading = document.getElementById("loading-profile");
+  const errorProfile = document.getElementById("error-profile");
   const nickname = document.getElementById("account-nickname-input");
 
   if (!modal || !input || !button || input.dataset.uxEnhanced === "true") {
@@ -111,29 +114,35 @@ function enhanceModal(): void {
     }, 0);
   });
 
-  input.addEventListener("keydown", (event) => {
-    if (event.key !== "Enter" || button.disabled) return;
-    event.preventDefault();
-    button.click();
-  });
+  input.addEventListener(
+    "keydown",
+    (event) => {
+      if (event.key !== "Enter") return;
+
+      event.preventDefault();
+      event.stopImmediatePropagation();
+
+      if (!button.disabled) {
+        button.click();
+      }
+    },
+    true,
+  );
 
   button.addEventListener("click", () => {
     if (button.disabled) return;
-    setButtonState(button, true, true);
-    button.setAttribute("aria-busy", "true");
-    helper.textContent = getMessage(
-      "accountCreationCheckingProfile" as MessageKey,
-      "Checking profile and creating account…",
-    );
-    helper.className = "mt-2 text-xs text-indigo-700";
+    setBusyState(button, helper);
   });
 
-  const stateObserver = new MutationObserver(() => {
+  const syncAsyncState = (): void => {
     const isLoading = Boolean(loading && !loading.classList.contains("hidden"));
-    if (!isLoading) {
-      button.removeAttribute("aria-busy");
-      updateInputState(input, button, helper);
+
+    if (isLoading) {
+      setBusyState(button, helper);
+      return;
     }
+
+    updateInputState(input, button, helper);
 
     if (
       nickname &&
@@ -141,13 +150,17 @@ function enhanceModal(): void {
     ) {
       (nickname as HTMLInputElement).focus();
     }
-  });
+  };
 
-  if (loading) {
-    stateObserver.observe(loading, {
-      attributes: true,
-      attributeFilter: ["class"],
-    });
+  const stateObserver = new MutationObserver(syncAsyncState);
+
+  for (const element of [loading, errorProfile]) {
+    if (element) {
+      stateObserver.observe(element, {
+        attributes: true,
+        attributeFilter: ["class"],
+      });
+    }
   }
 
   const nicknameStep = document.getElementById("step-add-nickname");
@@ -160,6 +173,7 @@ function enhanceModal(): void {
 
   const modalObserver = new MutationObserver(() => {
     if (!modal.classList.contains("hidden")) {
+      updateInputState(input, button, helper);
       window.setTimeout(() => input.focus(), 50);
     }
   });

--- a/entrypoints/options/accountCreationUX.ts
+++ b/entrypoints/options/accountCreationUX.ts
@@ -1,0 +1,172 @@
+import ArcadeApiService from "../../services/arcadeApiService";
+
+const PROFILE_URL_EXAMPLE =
+  "https://www.skills.google/public_profiles/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+function getMessage(key: string, fallback: string): string {
+  try {
+    return browser.i18n.getMessage(key) || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function ensureHelper(input: HTMLInputElement): HTMLElement {
+  const existing = document.getElementById("account-url-helper");
+  if (existing) return existing;
+
+  const helper = document.createElement("div");
+  helper.id = "account-url-helper";
+  helper.setAttribute("role", "status");
+  helper.setAttribute("aria-live", "polite");
+  helper.className = "mt-2 text-xs text-gray-500";
+  input.closest(".bg-white")?.appendChild(helper);
+  input.setAttribute("aria-describedby", helper.id);
+  return helper;
+}
+
+function setButtonState(
+  button: HTMLButtonElement,
+  enabled: boolean,
+  busy = false,
+): void {
+  button.disabled = !enabled || busy;
+  button.setAttribute("aria-disabled", String(!enabled || busy));
+  button.classList.toggle("opacity-60", !enabled || busy);
+  button.classList.toggle("cursor-not-allowed", !enabled || busy);
+  button.classList.toggle("cursor-pointer", enabled && !busy);
+}
+
+function updateInputState(
+  input: HTMLInputElement,
+  button: HTMLButtonElement,
+  helper: HTMLElement,
+): void {
+  const value = input.value.trim();
+  const isEmpty = value.length === 0;
+  const isValid = !isEmpty && ArcadeApiService.isValidProfileUrl(value);
+
+  input.classList.toggle("border-red-400", !isEmpty && !isValid);
+  input.classList.toggle("focus:border-red-500", !isEmpty && !isValid);
+  input.classList.toggle("border-emerald-400", isValid);
+  input.setAttribute("aria-invalid", String(!isEmpty && !isValid));
+
+  if (isEmpty) {
+    helper.textContent = getMessage(
+      "accountCreationPasteHint",
+      `Paste your public profile URL, for example: ${PROFILE_URL_EXAMPLE}`,
+    );
+    helper.className = "mt-2 text-xs text-gray-500";
+  } else if (isValid) {
+    helper.textContent = getMessage(
+      "accountCreationUrlReady",
+      "Profile URL looks valid. Press Enter or select Create account.",
+    );
+    helper.className = "mt-2 text-xs text-emerald-700";
+  } else {
+    helper.textContent = getMessage(
+      "errorInvalidProfileUrl",
+      "Enter a valid Google Cloud Skills Boost public profile URL.",
+    );
+    helper.className = "mt-2 text-xs text-red-600";
+  }
+
+  setButtonState(button, isValid);
+}
+
+function enhanceModal(): void {
+  const modal = document.getElementById("add-account-modal");
+  const input = document.getElementById(
+    "account-url-input",
+  ) as HTMLInputElement | null;
+  const button = document.getElementById(
+    "create-account-btn",
+  ) as HTMLButtonElement | null;
+  const loading = document.getElementById("loading-profile");
+  const nickname = document.getElementById("account-nickname-input");
+
+  if (!modal || !input || !button || input.dataset.uxEnhanced === "true") {
+    return;
+  }
+
+  input.dataset.uxEnhanced = "true";
+  input.autocomplete = "url";
+  input.inputMode = "url";
+  input.spellcheck = false;
+  input.placeholder = PROFILE_URL_EXAMPLE;
+
+  const helper = ensureHelper(input);
+  updateInputState(input, button, helper);
+
+  input.addEventListener("input", () => {
+    updateInputState(input, button, helper);
+  });
+
+  input.addEventListener("paste", () => {
+    window.setTimeout(() => {
+      input.value = input.value.trim();
+      updateInputState(input, button, helper);
+    }, 0);
+  });
+
+  input.addEventListener("keydown", (event) => {
+    if (event.key !== "Enter" || button.disabled) return;
+    event.preventDefault();
+    button.click();
+  });
+
+  button.addEventListener("click", () => {
+    if (button.disabled) return;
+    setButtonState(button, true, true);
+    button.setAttribute("aria-busy", "true");
+    helper.textContent = getMessage(
+      "accountCreationCheckingProfile",
+      "Checking profile and creating account…",
+    );
+    helper.className = "mt-2 text-xs text-indigo-700";
+  });
+
+  const stateObserver = new MutationObserver(() => {
+    const isLoading = Boolean(loading && !loading.classList.contains("hidden"));
+    if (!isLoading) {
+      button.removeAttribute("aria-busy");
+      updateInputState(input, button, helper);
+    }
+
+    if (nickname && !nickname.closest("#step-add-nickname")?.classList.contains("hidden")) {
+      (nickname as HTMLInputElement).focus();
+    }
+  });
+
+  if (loading) {
+    stateObserver.observe(loading, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+  }
+
+  const nicknameStep = document.getElementById("step-add-nickname");
+  if (nicknameStep) {
+    stateObserver.observe(nicknameStep, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+  }
+
+  const modalObserver = new MutationObserver(() => {
+    if (!modal.classList.contains("hidden")) {
+      window.setTimeout(() => input.focus(), 50);
+    }
+  });
+  modalObserver.observe(modal, {
+    attributes: true,
+    attributeFilter: ["class"],
+  });
+}
+
+export function initAccountCreationUX(): void {
+  enhanceModal();
+
+  const observer = new MutationObserver(() => enhanceModal());
+  observer.observe(document.body, { childList: true, subtree: true });
+}

--- a/entrypoints/options/main.tsx
+++ b/entrypoints/options/main.tsx
@@ -5,6 +5,7 @@ import { initDataManagementToggle } from "./dataManagementToggle";
 import { initUIToggles } from "./uiToggles";
 import { initNicknamePreview } from "./nicknamePreview";
 import { initNotificationSettings } from "./notificationSettings";
+import { initAccountCreationUX } from "./accountCreationUX";
 
 // Set document title
 document.title =
@@ -69,6 +70,7 @@ async function initializeOptionsPage() {
   initUIToggles();
   initNicknamePreview();
   initNotificationSettings();
+  initAccountCreationUX();
 }
 
 initializeOptionsPage().catch((error) => {


### PR DESCRIPTION
## Summary

Improve the account creation flow in the Options page without changing the existing account creation business logic.

## Changes

- Validate the public profile URL in real time.
- Disable the Create account button until the URL is valid.
- Trim pasted URLs automatically.
- Support pressing Enter to create an account.
- Add accessible live status feedback for validation and loading states.
- Focus the URL field when the modal opens.
- Focus the nickname field after account creation.
- Prevent repeated submission while profile data is loading.
- Keep the UX enhancement isolated in a dedicated module.

## Base

Created from `dev` and targets `dev`.