### PR TITLE
fix: prevent popup size jank on first paint

### DIFF
--- a/entrypoints/popup/compactModeSync.ts
+++ b/entrypoints/popup/compactModeSync.ts
@@ -1,0 +1,5 @@
+import CompactModePreferenceService from "../../services/compactModePreferenceService";
+
+void CompactModePreferenceService.initializeMirrorSync().catch((error) => {
+  console.debug("Failed to initialize compact mode mirror:", error);
+});

--- a/public/popup-size-bootstrap.js
+++ b/public/popup-size-bootstrap.js
@@ -1,0 +1,66 @@
+(() => {
+  const MIRROR_KEY = "eplus:popupCompactMode";
+  const STORAGE_KEYS = ["compactMode", "local:compactMode"];
+
+  const applyCompactState = (compact) => {
+    document.documentElement.dataset.popupCompact = compact ? "true" : "false";
+  };
+
+  const persistMirror = (compact) => {
+    try {
+      localStorage.setItem(MIRROR_KEY, compact ? "1" : "0");
+    } catch {
+      // localStorage can be unavailable in hardened browser contexts.
+    }
+  };
+
+  let hasMirror = false;
+  try {
+    const mirrored = localStorage.getItem(MIRROR_KEY);
+    if (mirrored === "1" || mirrored === "0") {
+      hasMirror = true;
+      applyCompactState(mirrored === "1");
+    }
+  } catch {
+    // Continue with extension storage as the fallback source.
+  }
+
+  const extensionStorage = globalThis.browser?.storage ?? globalThis.chrome?.storage;
+  const localArea = extensionStorage?.local;
+
+  if (localArea?.get) {
+    try {
+      const result = localArea.get(STORAGE_KEYS, (values) => {
+        const compact = values?.compactMode ?? values?.["local:compactMode"];
+        if (typeof compact !== "boolean") return;
+
+        persistMirror(compact);
+        if (!hasMirror) applyCompactState(compact);
+      });
+
+      if (result && typeof result.then === "function") {
+        result
+          .then((values) => {
+            const compact = values?.compactMode ?? values?.["local:compactMode"];
+            if (typeof compact !== "boolean") return;
+
+            persistMirror(compact);
+            if (!hasMirror) applyCompactState(compact);
+          })
+          .catch(() => undefined);
+      }
+    } catch {
+      // The regular popup initialization still restores the canonical state.
+    }
+  }
+
+  extensionStorage?.onChanged?.addListener?.((changes, areaName) => {
+    if (areaName !== "local") return;
+
+    const change = changes.compactMode ?? changes["local:compactMode"];
+    if (typeof change?.newValue !== "boolean") return;
+
+    persistMirror(change.newValue);
+    applyCompactState(change.newValue);
+  });
+})();

--- a/public/popup-size-bootstrap.js
+++ b/public/popup-size-bootstrap.js
@@ -1,66 +1,11 @@
 (() => {
-  const MIRROR_KEY = "eplus:popupCompactMode";
-  const STORAGE_KEYS = ["compactMode", "local:compactMode"];
-
-  const applyCompactState = (compact) => {
-    document.documentElement.dataset.popupCompact = compact ? "true" : "false";
-  };
-
-  const persistMirror = (compact) => {
-    try {
-      localStorage.setItem(MIRROR_KEY, compact ? "1" : "0");
-    } catch {
-      // localStorage can be unavailable in hardened browser contexts.
-    }
-  };
-
-  let hasMirror = false;
   try {
-    const mirrored = localStorage.getItem(MIRROR_KEY);
+    const mirrored = localStorage.getItem("eplus:popupCompactMode");
     if (mirrored === "1" || mirrored === "0") {
-      hasMirror = true;
-      applyCompactState(mirrored === "1");
+      document.documentElement.dataset.popupCompact =
+        mirrored === "1" ? "true" : "false";
     }
   } catch {
-    // Continue with extension storage as the fallback source.
+    // The regular popup initialization restores the canonical state.
   }
-
-  const extensionStorage = globalThis.browser?.storage ?? globalThis.chrome?.storage;
-  const localArea = extensionStorage?.local;
-
-  if (localArea?.get) {
-    try {
-      const result = localArea.get(STORAGE_KEYS, (values) => {
-        const compact = values?.compactMode ?? values?.["local:compactMode"];
-        if (typeof compact !== "boolean") return;
-
-        persistMirror(compact);
-        if (!hasMirror) applyCompactState(compact);
-      });
-
-      if (result && typeof result.then === "function") {
-        result
-          .then((values) => {
-            const compact = values?.compactMode ?? values?.["local:compactMode"];
-            if (typeof compact !== "boolean") return;
-
-            persistMirror(compact);
-            if (!hasMirror) applyCompactState(compact);
-          })
-          .catch(() => undefined);
-      }
-    } catch {
-      // The regular popup initialization still restores the canonical state.
-    }
-  }
-
-  extensionStorage?.onChanged?.addListener?.((changes, areaName) => {
-    if (areaName !== "local") return;
-
-    const change = changes.compactMode ?? changes["local:compactMode"];
-    if (typeof change?.newValue !== "boolean") return;
-
-    persistMirror(change.newValue);
-    applyCompactState(change.newValue);
-  });
 })();

--- a/services/compactModePreferenceService.ts
+++ b/services/compactModePreferenceService.ts
@@ -1,0 +1,49 @@
+const MIRROR_KEY = "eplus:popupCompactMode";
+const STORAGE_KEY = "local:compactMode" as const;
+
+const compactModeStorage = storage.defineItem<boolean>(STORAGE_KEY, {
+  defaultValue: false,
+});
+
+function applyDocumentState(compact: boolean): void {
+  document.documentElement.dataset.popupCompact = compact ? "true" : "false";
+}
+
+function persistMirror(compact: boolean): void {
+  try {
+    localStorage.setItem(MIRROR_KEY, compact ? "1" : "0");
+  } catch {
+    // localStorage may be unavailable in hardened browser contexts.
+  }
+}
+
+async function getValue(): Promise<boolean> {
+  return compactModeStorage.getValue();
+}
+
+async function setValue(compact: boolean): Promise<void> {
+  await compactModeStorage.setValue(compact);
+  persistMirror(compact);
+  applyDocumentState(compact);
+}
+
+async function initializeMirrorSync(): Promise<boolean> {
+  const compact = await getValue();
+  persistMirror(compact);
+  applyDocumentState(compact);
+
+  compactModeStorage.watch((nextValue) => {
+    persistMirror(nextValue);
+    applyDocumentState(nextValue);
+  });
+
+  return compact;
+}
+
+const CompactModePreferenceService = {
+  getValue,
+  setValue,
+  initializeMirrorSync,
+};
+
+export default CompactModePreferenceService;

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -1,6 +1,47 @@
 import { defineConfig } from "wxt";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react-swc";
+import type { Plugin } from "vite";
+
+function popupSizeBootstrapPlugin(): Plugin {
+  return {
+    name: "eplus-popup-size-bootstrap",
+    transformIndexHtml: {
+      order: "pre",
+      handler(html) {
+        if (!html.includes('id="popup-content"')) return html;
+
+        return {
+          html,
+          tags: [
+            {
+              tag: "style",
+              injectTo: "head-prepend",
+              children: `
+                html[data-popup-compact="true"] #popup-content {
+                  min-height: 0 !important;
+                }
+                html[data-popup-compact="true"] #section-announcement,
+                html[data-popup-compact="true"] #countdown-container,
+                html[data-popup-compact="true"] #section-activity,
+                html[data-popup-compact="true"] #keyboard-hint {
+                  display: none !important;
+                }
+              `,
+            },
+            {
+              tag: "script",
+              injectTo: "head-prepend",
+              attrs: {
+                src: "/popup-size-bootstrap.js",
+              },
+            },
+          ],
+        };
+      },
+    },
+  };
+}
 
 // See https://wxt.dev/api/config.html
 export default defineConfig({
@@ -17,6 +58,6 @@ export default defineConfig({
     },
   },
   vite: () => ({
-    plugins: [react(), tailwindcss()],
+    plugins: [popupSizeBootstrapPlugin(), react(), tailwindcss()],
   }),
 });

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -22,6 +22,8 @@ function popupSizeBootstrapPlugin(): Plugin {
                   min-height: 0 !important;
                 }
                 html[data-popup-compact="true"] #section-announcement,
+                html[data-popup-compact="true"] #section-badges,
+                html[data-popup-compact="true"] #milestones-section,
                 html[data-popup-compact="true"] #countdown-container,
                 html[data-popup-compact="true"] #section-activity,
                 html[data-popup-compact="true"] #keyboard-hint {
@@ -34,6 +36,14 @@ function popupSizeBootstrapPlugin(): Plugin {
               injectTo: "head-prepend",
               attrs: {
                 src: "/popup-size-bootstrap.js",
+              },
+            },
+            {
+              tag: "script",
+              injectTo: "head",
+              attrs: {
+                type: "module",
+                src: "/entrypoints/popup/compactModeSync.ts",
               },
             },
           ],


### PR DESCRIPTION
## Summary

Prevent the popup from briefly rendering at the full size before restoring compact mode.

## Root cause

The compact-mode preference is read asynchronously after the popup has already rendered with `min-h-[700px]`. When compact mode is restored, the popup shrinks after first paint and creates a visible size jump.

## Changes

- Add a pre-paint popup bootstrap injected only into the popup HTML.
- Mirror the compact preference in synchronous `localStorage` for startup layout only.
- Apply compact visibility and min-height rules before the popup content is painted.
- Keep WXT extension storage as the canonical preference source.
- Backfill and synchronize the mirror from `browser.storage` / `chrome.storage` changes.
- Preserve the existing compact/restore implementation in `main.tsx`.

## Compatibility

- Existing users without the mirror may see the old behavior once while the mirror is backfilled.
- After compact mode is toggled or read once, subsequent popup openings use the correct initial size.

## Base

Created from and targets `dev`.