### PR TITLE
Use /api/v2/arcade as Facilitator source of truth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,10 @@ WXT_API_URL=https://domain-api.com/
 WXT_API_KEY=your_publication_id_or_api_key
 
 # Arcade API
-WXT_ARCADE_POINT_URL=https://arcade.example.com/point
+# Current extension uses POST /api/v2/arcade. When omitted, it derives
+# /api/v2/arcade from the legacy WXT_ARCADE_POINT_URL value.
+WXT_ARCADE_POINT_V2_URL=https://hub.example.com/api/v2/arcade
+WXT_ARCADE_POINT_URL=https://hub.example.com/api/arcade
 
 # Firebase configuration (optional)
 WXT_FIREBASE_API_KEY=your_firebase_api_key

--- a/services/arcadeApiService.ts
+++ b/services/arcadeApiService.ts
@@ -1,30 +1,62 @@
 import axios from "axios";
 import type { ArcadeData } from "../types";
+import {
+  resetFacilitatorRulesToFallback,
+  syncFacilitatorRulesFromApi,
+} from "./facilitatorService";
 import { canonicalizeProfileUrl, extractProfileId } from "../utils/profileUrl";
 
 /**
- * Service to handle Arcade API operations
+ * Resolve the stable Arcade API v2 endpoint.
+ *
+ * WXT_ARCADE_POINT_V2_URL is preferred when configured. For existing release
+ * environments we can derive `/api/v2/arcade` from the legacy `/api/arcade`
+ * URL so a new secret is not required immediately. We never send a request to
+ * the legacy endpoint from this client.
+ */
+function getArcadeV2Endpoint(): string {
+  const explicit = String(import.meta.env.WXT_ARCADE_POINT_V2_URL || "").trim();
+  if (explicit) return explicit;
+
+  const legacy = String(import.meta.env.WXT_ARCADE_POINT_URL || "").trim();
+  if (!legacy) return "";
+
+  const derived = legacy.replace(/\/arcade(?:-public)?\/?$/i, "/v2/arcade");
+  return derived !== legacy ? derived : "";
+}
+
+/**
+ * Service to handle Arcade API operations.
  */
 const ArcadeApiService = {
   /**
-   * Fetch arcade data from the API
+   * Fetch Arcade data from the stable API v2 endpoint.
    */
   async fetchArcadeData(url: string): Promise<ArcadeData | null> {
     try {
+      const endpoint = getArcadeV2Endpoint();
+      if (!endpoint) return null;
+
       // Ensure we send the canonical host to the backend. If canonicalization
       // fails, still send the original URL (backend may handle it), but we
       // prefer canonical.
       const canonical = canonicalizeProfileUrl(url) || url;
-
       const profileId = extractProfileId(url);
-      const response = await axios.post(import.meta.env.WXT_ARCADE_POINT_URL, {
+      const response = await axios.post(endpoint, {
         url: canonical,
         profileId,
       });
 
       if (response.status === 200) {
-        const data = response.data;
-        // Add current timestamp as lastUpdated
+        const data = response.data as ArcadeData;
+
+        // API v2 exposes Facilitator metadata only at the top level. The API is
+        // the source of truth; if metadata is absent or invalid, reset to the
+        // local compatibility fallback instead of keeping stale prior rules.
+        if (!syncFacilitatorRulesFromApi(data.facilitator)) {
+          resetFacilitatorRulesToFallback();
+        }
+
         data.lastUpdated = new Date().toISOString();
         return data;
       }
@@ -36,7 +68,7 @@ const ArcadeApiService = {
   },
 
   /**
-   * Validate profile URL format
+   * Validate profile URL format.
    */
   isValidProfileUrl(url: string): boolean {
     const canonical = canonicalizeProfileUrl(url);

--- a/services/facilitatorService.ts
+++ b/services/facilitatorService.ts
@@ -1,7 +1,10 @@
 /**
- * Shared facilitator helpers: requirements, points mapping and calculation utilities
+ * Shared Facilitator helpers.
+ *
+ * API-provided milestone metadata is the source of truth. The local rules below
+ * are only a compatibility fallback for old cached/API responses that do not yet
+ * include facilitator.milestones.
  */
-// Types for facilitator counts and milestone requirements
 export type FacilitatorCounts = {
   faciGame?: number;
   faciTrivia?: number;
@@ -9,64 +12,174 @@ export type FacilitatorCounts = {
   faciCompletion?: number;
 };
 
+export type FacilitatorMilestoneRule = {
+  id: string;
+  games: number;
+  skillBadges: number;
+  basePoints: number;
+  bonusPoints: number;
+};
+
+export type FacilitatorApiMetadata = {
+  estimatedBonusPoints?: number;
+  milestoneBonusPoints?: number;
+  estimatedMilestone?: string | null;
+  milestonePolicy?: string;
+  milestones?: FacilitatorMilestoneRule[];
+};
+
 export type MilestoneRequirements = {
   games: number;
   trivia: number;
   skills: number;
   labfree: number;
+  basePoints?: number;
 };
 
+const FALLBACK_MILESTONE_REQUIREMENTS: Record<string, MilestoneRequirements> = {
+  1: { games: 6, trivia: 0, skills: 18, labfree: 0, basePoints: 15 },
+  2: { games: 8, trivia: 0, skills: 34, labfree: 0, basePoints: 25 },
+  3: { games: 10, trivia: 0, skills: 50, labfree: 0, basePoints: 35 },
+  ultimate: {
+    games: 12,
+    trivia: 0,
+    skills: 66,
+    labfree: 0,
+    basePoints: 45,
+  },
+};
+
+const FALLBACK_MILESTONE_POINTS: Record<string, number> = {
+  1: 5,
+  2: 15,
+  3: 25,
+  ultimate: 35,
+};
+
+/**
+ * Mutable shared objects are intentional: PopupUIService stores references to
+ * these objects, so syncing from the API updates the existing UI code without a
+ * second hard-coded ruleset.
+ */
 export const FACILITATOR_MILESTONE_REQUIREMENTS: Record<
   string,
   MilestoneRequirements
-> = {
-  1: { games: 6, trivia: 5, skills: 14, labfree: 6 },
-  2: { games: 8, trivia: 6, skills: 28, labfree: 12 },
-  3: { games: 10, trivia: 7, skills: 38, labfree: 18 },
-  ultimate: { games: 12, trivia: 8, skills: 52, labfree: 24 },
-};
+> = cloneRequirements(FALLBACK_MILESTONE_REQUIREMENTS);
 
 export const FACILITATOR_MILESTONE_POINTS: Record<string, number> = {
-  1: 2,
-  2: 8,
-  3: 15,
-  ultimate: 25,
+  ...FALLBACK_MILESTONE_POINTS,
 };
 
+/**
+ * Convert a milestone key to its comparable numeric rank.
+ */
 export function getMilestoneNumber(milestone: string): number {
   return milestone === "ultimate" ? 4 : Number.parseInt(milestone, 10) || 0;
 }
 
+/**
+ * Restore the shared Facilitator rule records to the local compatibility
+ * fallback. This prevents rules from a previous API response leaking into a
+ * later response that has missing or invalid metadata.
+ */
+export function resetFacilitatorRulesToFallback(): void {
+  replaceRecord(
+    FACILITATOR_MILESTONE_REQUIREMENTS,
+    cloneRequirements(FALLBACK_MILESTONE_REQUIREMENTS),
+  );
+  replaceRecord(FACILITATOR_MILESTONE_POINTS, FALLBACK_MILESTONE_POINTS);
+}
+
+/**
+ * Prefer the rules returned by facilitator.milestones. Returns true only when
+ * a valid API ruleset was applied. Invalid/missing metadata leaves the latest
+ * known/fallback rules untouched; API consumers should explicitly reset to the
+ * fallback when a response does not contain a valid ruleset.
+ */
+export function syncFacilitatorRulesFromApi(
+  facilitator: FacilitatorApiMetadata | null | undefined,
+): boolean {
+  if (
+    !Array.isArray(facilitator?.milestones) ||
+    facilitator.milestones.length === 0
+  ) {
+    return false;
+  }
+
+  const nextRequirements: Record<string, MilestoneRequirements> = {};
+  const nextPoints: Record<string, number> = {};
+
+  for (const rule of facilitator.milestones) {
+    const key = normalizeMilestoneKey(rule?.id);
+    const games = Number(rule?.games);
+    const skills = Number(rule?.skillBadges);
+    const basePoints = Number(rule?.basePoints);
+    const bonusPoints = Number(rule?.bonusPoints);
+
+    if (
+      !key ||
+      !Number.isFinite(games) ||
+      !Number.isFinite(skills) ||
+      !Number.isFinite(basePoints) ||
+      !Number.isFinite(bonusPoints) ||
+      games < 0 ||
+      skills < 0 ||
+      basePoints < 0 ||
+      bonusPoints < 0
+    ) {
+      continue;
+    }
+
+    nextRequirements[key] = {
+      games,
+      trivia: 0,
+      skills,
+      labfree: 0,
+      basePoints,
+    };
+    nextPoints[key] = bonusPoints;
+  }
+
+  if (Object.keys(nextRequirements).length === 0) {
+    return false;
+  }
+
+  replaceRecord(FACILITATOR_MILESTONE_REQUIREMENTS, nextRequirements);
+  replaceRecord(FACILITATOR_MILESTONE_POINTS, nextPoints);
+  return true;
+}
+
+/**
+ * Read the bonus directly from API metadata when available. This is useful for
+ * callers that already have the complete Arcade response and should not
+ * re-derive a value the backend has calculated.
+ */
+export function getFacilitatorBonusFromApi(
+  facilitator?: FacilitatorApiMetadata | null,
+): number | null {
+  const value =
+    facilitator?.milestoneBonusPoints ?? facilitator?.estimatedBonusPoints;
+  const parsed = Number(value);
+
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+/**
+ * Return the bonus for the highest completed Facilitator milestone.
+ */
 export function calculateFacilitatorBonus(
   faciCounts: FacilitatorCounts | null | undefined,
 ): number {
   if (!faciCounts) return 0;
-  const {
-    faciGame = 0,
-    faciTrivia = 0,
-    faciSkill = 0,
-    faciCompletion = 0,
-  } = faciCounts;
 
-  const current = {
-    games: faciGame,
-    trivia: faciTrivia,
-    skills: faciSkill,
-    labfree: faciCompletion,
-  };
-
+  const current = normalizeCounts(faciCounts);
   let highestCompletedMilestone = 0;
   let highestBonusPoints = 0;
 
-  for (const milestoneKey in FACILITATOR_MILESTONE_REQUIREMENTS) {
-    const requirements = FACILITATOR_MILESTONE_REQUIREMENTS[milestoneKey];
-    const isCompleted =
-      current.games >= requirements.games &&
-      current.trivia >= requirements.trivia &&
-      current.skills >= requirements.skills &&
-      current.labfree >= requirements.labfree;
-
-    if (!isCompleted) continue;
+  for (const [milestoneKey, requirements] of Object.entries(
+    FACILITATOR_MILESTONE_REQUIREMENTS,
+  )) {
+    if (!isCompleted(current, requirements)) continue;
 
     const points = FACILITATOR_MILESTONE_POINTS[milestoneKey] || 0;
     const milestoneNum = getMilestoneNumber(milestoneKey);
@@ -79,6 +192,9 @@ export function calculateFacilitatorBonus(
   return highestBonusPoints;
 }
 
+/**
+ * Return a per-milestone bonus breakdown while applying the highest-only rule.
+ */
 export function calculateMilestoneBonusBreakdown(
   faciCounts: FacilitatorCounts | null | undefined,
 ) {
@@ -90,39 +206,20 @@ export function calculateMilestoneBonusBreakdown(
     };
   }
 
-  const {
-    faciGame = 0,
-    faciTrivia = 0,
-    faciSkill = 0,
-    faciCompletion = 0,
-  } = faciCounts;
+  const current = normalizeCounts(faciCounts);
+  const milestoneBonus: Record<string, number> = {};
 
-  const current = {
-    games: faciGame,
-    trivia: faciTrivia,
-    skills: faciSkill,
-    labfree: faciCompletion,
-  };
-
-  const milestoneBonus: Record<string, number> = {
-    1: 0,
-    2: 0,
-    3: 0,
-    ultimate: 0,
-  };
+  for (const key of Object.keys(FACILITATOR_MILESTONE_REQUIREMENTS)) {
+    milestoneBonus[key] = 0;
+  }
 
   let highestCompletedMilestone = 0;
   let highestBonusPoints = 0;
 
-  for (const milestoneKey in FACILITATOR_MILESTONE_REQUIREMENTS) {
-    const requirements = FACILITATOR_MILESTONE_REQUIREMENTS[milestoneKey];
-    const isCompleted =
-      current.games >= requirements.games &&
-      current.trivia >= requirements.trivia &&
-      current.skills >= requirements.skills &&
-      current.labfree >= requirements.labfree;
-
-    if (!isCompleted) continue;
+  for (const [milestoneKey, requirements] of Object.entries(
+    FACILITATOR_MILESTONE_REQUIREMENTS,
+  )) {
+    if (!isCompleted(current, requirements)) continue;
 
     const points = FACILITATOR_MILESTONE_POINTS[milestoneKey] || 0;
     const milestoneNum = getMilestoneNumber(milestoneKey);
@@ -130,8 +227,9 @@ export function calculateMilestoneBonusBreakdown(
       highestCompletedMilestone = milestoneNum;
       highestBonusPoints = points;
 
-      // reset and set only the highest completed
-      for (const k of Object.keys(milestoneBonus)) milestoneBonus[k] = 0;
+      for (const key of Object.keys(milestoneBonus)) {
+        milestoneBonus[key] = 0;
+      }
       milestoneBonus[milestoneKey] = points;
     }
   }
@@ -141,4 +239,75 @@ export function calculateMilestoneBonusBreakdown(
     total: highestBonusPoints,
     highestCompleted: highestCompletedMilestone,
   };
+}
+
+/**
+ * Normalize optional API counts into the internal scoring shape.
+ */
+function normalizeCounts(faciCounts: FacilitatorCounts) {
+  const games = Number(faciCounts.faciGame) || 0;
+  const trivia = Number(faciCounts.faciTrivia) || 0;
+  const skills = Number(faciCounts.faciSkill) || 0;
+  const labfree = Number(faciCounts.faciCompletion) || 0;
+
+  return {
+    games,
+    trivia,
+    skills,
+    labfree,
+    basePoints: games + trivia + skills * 0.5,
+  };
+}
+
+/**
+ * Check whether normalized counts satisfy one milestone requirement set.
+ */
+function isCompleted(
+  current: ReturnType<typeof normalizeCounts>,
+  requirements: MilestoneRequirements,
+): boolean {
+  return (
+    current.games >= requirements.games &&
+    current.trivia >= requirements.trivia &&
+    current.skills >= requirements.skills &&
+    current.labfree >= requirements.labfree &&
+    current.basePoints >= (requirements.basePoints ?? 0)
+  );
+}
+
+/**
+ * Normalize API milestone IDs such as milestone_1, milestone-1, 1, and ultimate.
+ */
+function normalizeMilestoneKey(id: unknown): string | null {
+  const value = String(id ?? "")
+    .trim()
+    .toLowerCase();
+  if (value === "ultimate") return "ultimate";
+
+  const match = /^(?:milestone[_-]?)?(\d+)$/.exec(value);
+  return match?.[1] || null;
+}
+
+/**
+ * Replace a record's contents in place so existing UI references remain valid.
+ */
+function replaceRecord<T>(
+  target: Record<string, T>,
+  source: Record<string, T>,
+): void {
+  for (const key of Object.keys(target)) {
+    Reflect.deleteProperty(target, key);
+  }
+  Object.assign(target, source);
+}
+
+/**
+ * Deep-enough clone for the flat milestone requirement values used by the UI.
+ */
+function cloneRequirements(
+  source: Record<string, MilestoneRequirements>,
+): Record<string, MilestoneRequirements> {
+  return Object.fromEntries(
+    Object.entries(source).map(([key, value]) => [key, { ...value }]),
+  );
 }

--- a/tests/services/arcadeApiService.test.ts
+++ b/tests/services/arcadeApiService.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import ArcadeApiService from "../../services/arcadeApiService";
+import {
+  FACILITATOR_MILESTONE_POINTS,
+  FACILITATOR_MILESTONE_REQUIREMENTS,
+  resetFacilitatorRulesToFallback,
+  syncFacilitatorRulesFromApi,
+} from "../../services/facilitatorService";
 
 // Mock axios
 vi.mock("axios", () => ({
@@ -8,13 +14,15 @@ vi.mock("axios", () => ({
   },
 }));
 
-// Mock import.meta.env
-vi.stubEnv("WXT_ARCADE_POINT_URL", "https://api.example.com/arcade");
+// Existing deployments can keep the old secret; the client derives /api/v2/arcade.
+vi.stubEnv("WXT_ARCADE_POINT_URL", "https://api.example.com/api/arcade");
+vi.stubEnv("WXT_ARCADE_POINT_V2_URL", "");
 
 import axios from "axios";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  resetFacilitatorRulesToFallback();
 });
 
 describe("ArcadeApiService.isValidProfileUrl", () => {
@@ -70,6 +78,81 @@ describe("ArcadeApiService.fetchArcadeData", () => {
     expect(result?.lastUpdated).toBeTruthy();
   });
 
+  it("calls /api/v2/arcade, not the legacy /api/arcade endpoint", async () => {
+    vi.mocked(axios.post).mockResolvedValueOnce({ status: 200, data: {} });
+
+    await ArcadeApiService.fetchArcadeData(
+      "https://www.skills.google/public_profiles/abc123",
+    );
+
+    expect(axios.post).toHaveBeenCalledWith(
+      "https://api.example.com/api/v2/arcade",
+      expect.any(Object),
+    );
+  });
+
+  it("uses top-level facilitator rules from the v2 response", async () => {
+    vi.mocked(axios.post).mockResolvedValueOnce({
+      status: 200,
+      data: {
+        facilitator: {
+          milestones: [
+            {
+              id: "milestone_1",
+              games: 2,
+              skillBadges: 4,
+              basePoints: 4,
+              bonusPoints: 7,
+            },
+          ],
+        },
+      },
+    });
+
+    await ArcadeApiService.fetchArcadeData(
+      "https://www.skills.google/public_profiles/abc123",
+    );
+
+    expect(FACILITATOR_MILESTONE_REQUIREMENTS["1"]).toEqual({
+      games: 2,
+      trivia: 0,
+      skills: 4,
+      labfree: 0,
+      basePoints: 4,
+    });
+    expect(FACILITATOR_MILESTONE_POINTS["1"]).toBe(7);
+  });
+
+  it("restores fallback rules when v2 metadata is missing", async () => {
+    syncFacilitatorRulesFromApi({
+      milestones: [
+        {
+          id: "milestone_1",
+          games: 2,
+          skillBadges: 4,
+          basePoints: 4,
+          bonusPoints: 99,
+        },
+      ],
+    });
+    expect(FACILITATOR_MILESTONE_POINTS["1"]).toBe(99);
+
+    vi.mocked(axios.post).mockResolvedValueOnce({ status: 200, data: {} });
+
+    await ArcadeApiService.fetchArcadeData(
+      "https://www.skills.google/public_profiles/abc123",
+    );
+
+    expect(FACILITATOR_MILESTONE_REQUIREMENTS["1"]).toEqual({
+      games: 6,
+      trivia: 0,
+      skills: 18,
+      labfree: 0,
+      basePoints: 15,
+    });
+    expect(FACILITATOR_MILESTONE_POINTS["1"]).toBe(5);
+  });
+
   it("adds lastUpdated timestamp to returned data", async () => {
     vi.mocked(axios.post).mockResolvedValueOnce({ status: 200, data: {} });
 
@@ -112,7 +195,7 @@ describe("ArcadeApiService.fetchArcadeData", () => {
     );
 
     expect(axios.post).toHaveBeenCalledWith(
-      expect.any(String),
+      "https://api.example.com/api/v2/arcade",
       expect.objectContaining({
         url: expect.stringContaining("www.skills.google"),
       }),
@@ -127,7 +210,7 @@ describe("ArcadeApiService.fetchArcadeData", () => {
     );
 
     expect(axios.post).toHaveBeenCalledWith(
-      expect.any(String),
+      "https://api.example.com/api/v2/arcade",
       expect.objectContaining({ profileId: "myprofile123" }),
     );
   });

--- a/tests/services/facilitatorService.test.ts
+++ b/tests/services/facilitatorService.test.ts
@@ -5,6 +5,8 @@ import {
   calculateMilestoneBonusBreakdown,
   FACILITATOR_MILESTONE_REQUIREMENTS,
   FACILITATOR_MILESTONE_POINTS,
+  getFacilitatorBonusFromApi,
+  syncFacilitatorRulesFromApi,
 } from "../../services/facilitatorService";
 
 describe("getMilestoneNumber", () => {
@@ -24,6 +26,30 @@ describe("getMilestoneNumber", () => {
   });
 });
 
+describe("Arcade Facilitators fallback rules", () => {
+  it("keeps the latest 2026 rules only as compatibility fallback", () => {
+    expect(FACILITATOR_MILESTONE_REQUIREMENTS).toEqual({
+      1: { games: 6, trivia: 0, skills: 18, labfree: 0, basePoints: 15 },
+      2: { games: 8, trivia: 0, skills: 34, labfree: 0, basePoints: 25 },
+      3: { games: 10, trivia: 0, skills: 50, labfree: 0, basePoints: 35 },
+      ultimate: {
+        games: 12,
+        trivia: 0,
+        skills: 66,
+        labfree: 0,
+        basePoints: 45,
+      },
+    });
+
+    expect(FACILITATOR_MILESTONE_POINTS).toEqual({
+      1: 5,
+      2: 15,
+      3: 25,
+      ultimate: 35,
+    });
+  });
+});
+
 describe("calculateFacilitatorBonus", () => {
   it("returns 0 for null/undefined faciCounts", () => {
     expect(calculateFacilitatorBonus(null)).toBe(0);
@@ -32,72 +58,78 @@ describe("calculateFacilitatorBonus", () => {
   it("returns 0 when no milestone is completed", () => {
     expect(
       calculateFacilitatorBonus({
-        faciGame: 1,
-        faciTrivia: 1,
-        faciSkill: 1,
-        faciCompletion: 1,
+        faciGame: 5,
+        faciTrivia: 99,
+        faciSkill: 17,
+        faciCompletion: 99,
       }),
     ).toBe(0);
   });
 
-  it("returns milestone 1 bonus (2 pts) when milestone 1 is met", () => {
-    const req = FACILITATOR_MILESTONE_REQUIREMENTS["1"];
+  it("does not require trivia or completion for 2026 milestone eligibility", () => {
     expect(
       calculateFacilitatorBonus({
-        faciGame: req.games,
-        faciTrivia: req.trivia,
-        faciSkill: req.skills,
-        faciCompletion: req.labfree,
+        faciGame: 6,
+        faciTrivia: 0,
+        faciSkill: 18,
+        faciCompletion: 0,
       }),
-    ).toBe(FACILITATOR_MILESTONE_POINTS["1"]);
+    ).toBe(5);
   });
 
-  it("returns milestone 2 bonus (8 pts) when milestone 2 is met", () => {
-    const req = FACILITATOR_MILESTONE_REQUIREMENTS["2"];
+  it("returns milestone 1 bonus for the real 6 game / 34 skill profile", () => {
     expect(
       calculateFacilitatorBonus({
-        faciGame: req.games,
-        faciTrivia: req.trivia,
-        faciSkill: req.skills,
-        faciCompletion: req.labfree,
+        faciGame: 6,
+        faciTrivia: 0,
+        faciSkill: 34,
+        faciCompletion: 0,
       }),
-    ).toBe(FACILITATOR_MILESTONE_POINTS["2"]);
+    ).toBe(5);
   });
 
-  it("returns milestone 3 bonus (15 pts) when milestone 3 is met", () => {
-    const req = FACILITATOR_MILESTONE_REQUIREMENTS["3"];
+  it("returns milestone 2 bonus when milestone 2 is met", () => {
     expect(
       calculateFacilitatorBonus({
-        faciGame: req.games,
-        faciTrivia: req.trivia,
-        faciSkill: req.skills,
-        faciCompletion: req.labfree,
+        faciGame: 8,
+        faciTrivia: 0,
+        faciSkill: 34,
+        faciCompletion: 0,
       }),
-    ).toBe(FACILITATOR_MILESTONE_POINTS["3"]);
+    ).toBe(15);
   });
 
-  it("returns ultimate bonus (25 pts) when ultimate milestone is met", () => {
-    const req = FACILITATOR_MILESTONE_REQUIREMENTS["ultimate"];
+  it("returns milestone 3 bonus when milestone 3 is met", () => {
     expect(
       calculateFacilitatorBonus({
-        faciGame: req.games,
-        faciTrivia: req.trivia,
-        faciSkill: req.skills,
-        faciCompletion: req.labfree,
+        faciGame: 10,
+        faciTrivia: 0,
+        faciSkill: 50,
+        faciCompletion: 0,
       }),
-    ).toBe(FACILITATOR_MILESTONE_POINTS["ultimate"]);
+    ).toBe(25);
+  });
+
+  it("returns ultimate bonus when ultimate is met", () => {
+    expect(
+      calculateFacilitatorBonus({
+        faciGame: 12,
+        faciTrivia: 0,
+        faciSkill: 66,
+        faciCompletion: 0,
+      }),
+    ).toBe(35);
   });
 
   it("returns highest completed milestone bonus only", () => {
-    // Meets milestone 2 but not 3
-    const req2 = FACILITATOR_MILESTONE_REQUIREMENTS["2"];
-    const result = calculateFacilitatorBonus({
-      faciGame: req2.games,
-      faciTrivia: req2.trivia,
-      faciSkill: req2.skills,
-      faciCompletion: req2.labfree,
-    });
-    expect(result).toBe(FACILITATOR_MILESTONE_POINTS["2"]);
+    expect(
+      calculateFacilitatorBonus({
+        faciGame: 8,
+        faciTrivia: 0,
+        faciSkill: 50,
+        faciCompletion: 0,
+      }),
+    ).toBe(15);
   });
 
   it("uses 0 as default for missing counts", () => {
@@ -113,47 +145,95 @@ describe("calculateMilestoneBonusBreakdown", () => {
     expect(result.milestones["1"]).toBe(0);
   });
 
-  it("returns correct breakdown for milestone 1", () => {
-    const req = FACILITATOR_MILESTONE_REQUIREMENTS["1"];
+  it("returns the real profile as milestone 1 with +5 points", () => {
     const result = calculateMilestoneBonusBreakdown({
-      faciGame: req.games,
-      faciTrivia: req.trivia,
-      faciSkill: req.skills,
-      faciCompletion: req.labfree,
+      faciGame: 6,
+      faciTrivia: 0,
+      faciSkill: 34,
+      faciCompletion: 0,
     });
+
     expect(result.highestCompleted).toBe(1);
-    expect(result.total).toBe(FACILITATOR_MILESTONE_POINTS["1"]);
-    expect(result.milestones["1"]).toBe(FACILITATOR_MILESTONE_POINTS["1"]);
-    // Other milestones should be 0
+    expect(result.total).toBe(5);
+    expect(result.milestones["1"]).toBe(5);
     expect(result.milestones["2"]).toBe(0);
+    expect(result.milestones["3"]).toBe(0);
+    expect(result.milestones.ultimate).toBe(0);
   });
 
   it("returns correct breakdown for ultimate milestone", () => {
-    const req = FACILITATOR_MILESTONE_REQUIREMENTS["ultimate"];
     const result = calculateMilestoneBonusBreakdown({
-      faciGame: req.games,
-      faciTrivia: req.trivia,
-      faciSkill: req.skills,
-      faciCompletion: req.labfree,
+      faciGame: 12,
+      faciTrivia: 0,
+      faciSkill: 66,
+      faciCompletion: 0,
     });
+
     expect(result.highestCompleted).toBe(4);
-    expect(result.total).toBe(FACILITATOR_MILESTONE_POINTS["ultimate"]);
-    expect(result.milestones["ultimate"]).toBe(
-      FACILITATOR_MILESTONE_POINTS["ultimate"],
-    );
+    expect(result.total).toBe(35);
+    expect(result.milestones.ultimate).toBe(35);
+  });
+});
+
+describe("API-provided Facilitator rules", () => {
+  it("reads the backend-calculated bonus directly when present", () => {
+    expect(getFacilitatorBonusFromApi({ estimatedBonusPoints: 5 })).toBe(5);
+    expect(
+      getFacilitatorBonusFromApi({
+        estimatedBonusPoints: 5,
+        milestoneBonusPoints: 15,
+      }),
+    ).toBe(15);
+    expect(getFacilitatorBonusFromApi()).toBeNull();
   });
 
-  it("only assigns bonus to highest completed milestone", () => {
-    const req = FACILITATOR_MILESTONE_REQUIREMENTS["2"];
-    const result = calculateMilestoneBonusBreakdown({
-      faciGame: req.games,
-      faciTrivia: req.trivia,
-      faciSkill: req.skills,
-      faciCompletion: req.labfree,
+  it("replaces shared requirements and bonus values from the API", () => {
+    const applied = syncFacilitatorRulesFromApi({
+      milestonePolicy: "highest_only",
+      milestones: [
+        {
+          id: "milestone_1",
+          games: 2,
+          skillBadges: 4,
+          basePoints: 4,
+          bonusPoints: 7,
+        },
+        {
+          id: "milestone_2",
+          games: 3,
+          skillBadges: 6,
+          basePoints: 6,
+          bonusPoints: 11,
+        },
+        {
+          id: "ultimate",
+          games: 4,
+          skillBadges: 8,
+          basePoints: 8,
+          bonusPoints: 19,
+        },
+      ],
     });
-    // Only milestone 2 should have points, others 0
-    expect(result.milestones["1"]).toBe(0);
-    expect(result.milestones["2"]).toBe(FACILITATOR_MILESTONE_POINTS["2"]);
-    expect(result.milestones["3"]).toBe(0);
+
+    expect(applied).toBe(true);
+    expect(FACILITATOR_MILESTONE_REQUIREMENTS["1"]).toEqual({
+      games: 2,
+      trivia: 0,
+      skills: 4,
+      labfree: 0,
+      basePoints: 4,
+    });
+    expect(FACILITATOR_MILESTONE_POINTS["1"]).toBe(7);
+    expect(FACILITATOR_MILESTONE_POINTS["2"]).toBe(11);
+    expect(FACILITATOR_MILESTONE_POINTS.ultimate).toBe(19);
+
+    expect(
+      calculateFacilitatorBonus({
+        faciGame: 2,
+        faciSkill: 4,
+        faciTrivia: 0,
+        faciCompletion: 0,
+      }),
+    ).toBe(7);
   });
 });

--- a/types/popup.ts
+++ b/types/popup.ts
@@ -14,8 +14,41 @@ export interface UserDetail {
   completedBadgeIds?: CompletedBadge[];
 }
 
+export interface FacilitatorMilestoneRule {
+  id: string;
+  games: number;
+  skillBadges: number;
+  basePoints: number;
+  bonusPoints: number;
+}
+
+export interface FacilitatorApiMetadata {
+  status?: string;
+  verification?: string;
+  startsAt?: string;
+  endsAt?: string;
+  skillBadges?: number;
+  gameBadges?: number;
+  triviaBadges?: number;
+  estimatedMilestone?: string | null;
+  estimatedBonusPoints?: number;
+  milestoneBonusPoints?: number;
+  bonusIncludedInTotal?: boolean;
+  gamePoints?: number;
+  skillPoints?: number;
+  triviaPoints?: number;
+  baseArcadePoints?: number;
+  pointsAlreadyIncludedInArcadeTotal?: number;
+  estimatedFacilitatorPoints?: number;
+  bonusMilestonePoints?: number | null;
+  bonusMilestoneStatus?: string;
+  milestonePolicy?: string;
+  milestones?: FacilitatorMilestoneRule[];
+}
+
 export interface ArcadeData {
   success?: boolean;
+  apiVersion?: number;
   userDetails?: UserDetail | UserDetail[]; // Support both single object and array
   arcadePoints?: {
     totalPoints?: number;
@@ -23,6 +56,7 @@ export interface ArcadeData {
     triviaPoints?: number;
     skillPoints?: number;
     specialPoints?: number;
+    completionPoints?: number;
   };
   faciCounts?: {
     faciGame?: number;
@@ -31,6 +65,14 @@ export interface ArcadeData {
     faciCompletion?: number;
     completedFaciCount?: number;
     completedFaciSkillCount?: number;
+  };
+  // Canonical Arcade v2 Facilitator contract.
+  facilitator?: FacilitatorApiMetadata;
+  // Deprecated legacy shape retained only so previously stored responses can
+  // still be read safely. Current network requests do not consume this field.
+  beta?: {
+    facilitator?: FacilitatorApiMetadata;
+    [key: string]: unknown;
   };
   totalArcadePoints?: number;
   badges?: BadgeData[];


### PR DESCRIPTION
## Goal

Move the current extension to the new versioned Arcade API while keeping the old backend endpoint untouched for already-released extension versions.

## Client behavior

- New builds call `POST /api/v2/arcade`; they do not call the legacy `/api/arcade` endpoint.
- `WXT_ARCADE_POINT_V2_URL` can explicitly configure the v2 URL.
- Existing deployments do not require a new secret immediately: when only `WXT_ARCADE_POINT_URL=.../api/arcade` exists, the client derives `.../api/v2/arcade` but never sends a request to the old endpoint.
- Facilitator rules are read from top-level `facilitator.milestones` in the v2 response.
- Local 2026 rules remain only as a fallback for old cached data.
- The TypeScript `beta` shape is retained only to safely deserialize previously stored responses; current network code does not consume it.

## Backend

Paired backend PR: `hoangsvit/hub.eplus.dev#146`.

## Compatibility

No extension storage keys, `faciCounts`, `arcadePoints`, badge arrays, or account fields are removed. Old extension releases continue using the unchanged old endpoint; new extension releases use `/api/v2/arcade`.

## Regression coverage

API service tests explicitly assert the request is sent to `/api/v2/arcade`, not `/api/arcade`.