### PR TITLE
fix: sync Facilitator bonus labels with API rules

### DIFF
--- a/services/arcadeApiService.ts
+++ b/services/arcadeApiService.ts
@@ -87,10 +87,7 @@ function syncFacilitatorRuleLabels(): void {
   );
   const currentText = maximumNote.textContent?.trim() || "";
   const nextText = /\d+(?:[.,]\d+)?/u.test(currentText)
-    ? currentText.replace(
-        /\d+(?:[.,]\d+)?/u,
-        formatBonusPoints(maximumPoints),
-      )
+    ? currentText.replace(/\d+(?:[.,]\d+)?/u, formatBonusPoints(maximumPoints))
     : `Maximum possible: ${formatBonusPoints(maximumPoints)} points (highest milestone only)`;
 
   if (currentText !== nextText) {

--- a/services/arcadeApiService.ts
+++ b/services/arcadeApiService.ts
@@ -107,6 +107,7 @@ function initializeFacilitatorRuleLabelSync(): void {
     return;
   }
 
+  /** Start label synchronization once the popup DOM is ready. */
   const start = (): void => {
     syncFacilitatorRuleLabels();
     if (!document.body || facilitatorLabelObserver) return;
@@ -181,8 +182,8 @@ const ArcadeApiService = {
     if (!canonical) return false;
 
     try {
-      const u = new URL(canonical);
-      return /\/public_profiles\//.test(u.pathname);
+      const parsedUrl = new URL(canonical);
+      return /\/public_profiles\//.test(parsedUrl.pathname);
     } catch {
       return false;
     }

--- a/services/arcadeApiService.ts
+++ b/services/arcadeApiService.ts
@@ -1,10 +1,20 @@
 import axios from "axios";
 import type { ArcadeData } from "../types";
 import {
+  FACILITATOR_MILESTONE_POINTS,
   resetFacilitatorRulesToFallback,
   syncFacilitatorRulesFromApi,
 } from "./facilitatorService";
 import { canonicalizeProfileUrl, extractProfileId } from "../utils/profileUrl";
+
+const FACILITATOR_BONUS_LABEL_KEYS: Record<string, string> = {
+  1: "milestone1Bonus",
+  2: "milestone2Bonus",
+  3: "milestone3Bonus",
+  ultimate: "milestoneUltimateBonus",
+};
+
+let facilitatorLabelObserver: MutationObserver | null = null;
 
 /**
  * Resolve the stable Arcade API v2 endpoint.
@@ -24,6 +34,104 @@ function getArcadeV2Endpoint(): string {
   const derived = legacy.replace(/\/arcade(?:-public)?\/?$/i, "/v2/arcade");
   return derived !== legacy ? derived : "";
 }
+
+/** Format a bonus value without unnecessary trailing decimals. */
+function formatBonusPoints(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+/** Replace only the numeric bonus prefix while preserving localized text. */
+function replaceBonusValue(text: string, points: number): string {
+  const formatted = `+${formatBonusPoints(points)}`;
+  const pattern = /\+\s*-?\d+(?:[.,]\d+)?/u;
+
+  return pattern.test(text)
+    ? text.replace(pattern, formatted)
+    : `${formatted} Bonus Points`;
+}
+
+/**
+ * Keep Facilitator card bonus labels synchronized with the active API rules.
+ * The text after the numeric value stays localized; only the number is replaced.
+ */
+function syncFacilitatorRuleLabels(): void {
+  if (typeof document === "undefined") return;
+
+  for (const [milestone, i18nKey] of Object.entries(
+    FACILITATOR_BONUS_LABEL_KEYS,
+  )) {
+    const element = document.querySelector<HTMLElement>(
+      `[data-i18n="${i18nKey}"]`,
+    );
+    if (!element) continue;
+
+    const points = Number(FACILITATOR_MILESTONE_POINTS[milestone] ?? 0);
+    const currentText = element.textContent?.trim() || "";
+    const nextText = replaceBonusValue(currentText, points);
+
+    if (currentText !== nextText) {
+      element.textContent = nextText;
+    }
+  }
+
+  const maximumNote = document.querySelector<HTMLElement>(
+    '[data-i18n="maxPossibleNote"]',
+  );
+  if (!maximumNote) return;
+
+  const maximumPoints = Math.max(
+    0,
+    ...Object.values(FACILITATOR_MILESTONE_POINTS).map((value) =>
+      Number.isFinite(Number(value)) ? Number(value) : 0,
+    ),
+  );
+  const currentText = maximumNote.textContent?.trim() || "";
+  const nextText = /\d+(?:[.,]\d+)?/u.test(currentText)
+    ? currentText.replace(
+        /\d+(?:[.,]\d+)?/u,
+        formatBonusPoints(maximumPoints),
+      )
+    : `Maximum possible: ${formatBonusPoints(maximumPoints)} points (highest milestone only)`;
+
+  if (currentText !== nextText) {
+    maximumNote.textContent = nextText;
+  }
+}
+
+/**
+ * Re-apply dynamic rule values after localization mutates the static HTML text.
+ */
+function initializeFacilitatorRuleLabelSync(): void {
+  if (
+    typeof document === "undefined" ||
+    typeof MutationObserver === "undefined" ||
+    facilitatorLabelObserver
+  ) {
+    return;
+  }
+
+  const start = (): void => {
+    syncFacilitatorRuleLabels();
+    if (!document.body || facilitatorLabelObserver) return;
+
+    facilitatorLabelObserver = new MutationObserver(() => {
+      syncFacilitatorRuleLabels();
+    });
+    facilitatorLabelObserver.observe(document.body, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", start, { once: true });
+  } else {
+    start();
+  }
+}
+
+initializeFacilitatorRuleLabelSync();
 
 /**
  * Service to handle Arcade API operations.
@@ -56,6 +164,7 @@ const ArcadeApiService = {
         if (!syncFacilitatorRulesFromApi(data.facilitator)) {
           resetFacilitatorRulesToFallback();
         }
+        syncFacilitatorRuleLabels();
 
         data.lastUpdated = new Date().toISOString();
         return data;

--- a/tests/services/arcadeApiService.test.ts
+++ b/tests/services/arcadeApiService.test.ts
@@ -23,6 +23,7 @@ import axios from "axios";
 beforeEach(() => {
   vi.clearAllMocks();
   resetFacilitatorRulesToFallback();
+  document.body.innerHTML = "";
 });
 
 describe("ArcadeApiService.isValidProfileUrl", () => {
@@ -121,6 +122,106 @@ describe("ArcadeApiService.fetchArcadeData", () => {
       basePoints: 4,
     });
     expect(FACILITATOR_MILESTONE_POINTS["1"]).toBe(7);
+  });
+
+  it("updates rendered facilitator labels from API rule values", async () => {
+    document.body.innerHTML = `
+      <span data-i18n="milestone1Bonus">+2 Bonus Points</span>
+      <span data-i18n="milestone2Bonus">+8 Bonus Points</span>
+      <span data-i18n="milestone3Bonus">+15 Bonus Points</span>
+      <span data-i18n="milestoneUltimateBonus">+25 Bonus Points</span>
+      <span data-i18n="maxPossibleNote">Maximum possible: 25 points (highest milestone only)</span>
+    `;
+
+    vi.mocked(axios.post).mockResolvedValueOnce({
+      status: 200,
+      data: {
+        facilitator: {
+          milestones: [
+            {
+              id: "milestone_1",
+              games: 6,
+              skillBadges: 18,
+              basePoints: 15,
+              bonusPoints: 5,
+            },
+            {
+              id: "milestone_2",
+              games: 8,
+              skillBadges: 34,
+              basePoints: 25,
+              bonusPoints: 15,
+            },
+            {
+              id: "milestone_3",
+              games: 10,
+              skillBadges: 50,
+              basePoints: 35,
+              bonusPoints: 25,
+            },
+            {
+              id: "ultimate",
+              games: 12,
+              skillBadges: 66,
+              basePoints: 45,
+              bonusPoints: 35,
+            },
+          ],
+        },
+      },
+    });
+
+    await ArcadeApiService.fetchArcadeData(
+      "https://www.skills.google/public_profiles/abc123",
+    );
+
+    expect(
+      document.querySelector('[data-i18n="milestone1Bonus"]')?.textContent,
+    ).toBe("+5 Bonus Points");
+    expect(
+      document.querySelector('[data-i18n="milestone2Bonus"]')?.textContent,
+    ).toBe("+15 Bonus Points");
+    expect(
+      document.querySelector('[data-i18n="milestone3Bonus"]')?.textContent,
+    ).toBe("+25 Bonus Points");
+    expect(
+      document.querySelector('[data-i18n="milestoneUltimateBonus"]')
+        ?.textContent,
+    ).toBe("+35 Bonus Points");
+    expect(
+      document.querySelector('[data-i18n="maxPossibleNote"]')?.textContent,
+    ).toBe("Maximum possible: 35 points (highest milestone only)");
+  });
+
+  it("preserves localized label text while replacing the bonus number", async () => {
+    document.body.innerHTML = `
+      <span data-i18n="milestone1Bonus">+2 Điểm thưởng</span>
+    `;
+
+    vi.mocked(axios.post).mockResolvedValueOnce({
+      status: 200,
+      data: {
+        facilitator: {
+          milestones: [
+            {
+              id: "milestone_1",
+              games: 6,
+              skillBadges: 18,
+              basePoints: 15,
+              bonusPoints: 5,
+            },
+          ],
+        },
+      },
+    });
+
+    await ArcadeApiService.fetchArcadeData(
+      "https://www.skills.google/public_profiles/abc123",
+    );
+
+    expect(
+      document.querySelector('[data-i18n="milestone1Bonus"]')?.textContent,
+    ).toBe("+5 Điểm thưởng");
   });
 
   it("restores fallback rules when v2 metadata is missing", async () => {


### PR DESCRIPTION
## Summary

Fix the popup still showing legacy Facilitator bonus labels (`+2/+8/+15/+25`) after the scoring rules moved to Arcade API v2.

## Root cause

The scoring service was already using API-provided rules, but the milestone card labels and maximum-bonus note were static i18n text. `localizeElements()` also runs after the initial popup render, so it could overwrite dynamically calculated values back to the old strings.

## Changes

- Keep milestone-card bonus numbers synchronized with `FACILITATOR_MILESTONE_POINTS` hydrated from `/api/v2/arcade`.
- Preserve the localized text around the numeric bonus value.
- Update the maximum-possible note from the active rule set.
- Re-apply dynamic values when localization mutates the DOM.
- Add regression coverage for `+5/+15/+25/+35` and localized labels.

## Compatibility

- Targets `dev`.
- Does not change the API contract or legacy endpoint behavior.
- Falls back to local 2026 rules when v2 metadata is missing or invalid.