### PR TITLE
Sign Arcade v2 API requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ WXT_API_KEY=your_publication_id_or_api_key
 # /api/v2/arcade from the legacy WXT_ARCADE_POINT_URL value.
 WXT_ARCADE_POINT_V2_URL=https://hub.example.com/api/v2/arcade
 WXT_ARCADE_POINT_URL=https://hub.example.com/api/arcade
+# Inject these only from release/deployment secrets. Do not commit real values.
+WXT_ARCADE_CLIENT_KEY=
+WXT_ARCADE_CLIENT_SECRET=
 
 # Firebase configuration (optional)
 WXT_FIREBASE_API_KEY=your_firebase_api_key

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,8 @@ jobs:
           set -euo pipefail
 
           for name in WXT_ARCADE_CLIENT_KEY WXT_ARCADE_CLIENT_SECRET; do
-            if [ -z "${!name:-}" ]; then
+            normalized="${!name//[[:space:]]/}"
+            if [ -z "$normalized" ]; then
               echo "::error::$name is required for signed Arcade API releases."
               exit 1
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ jobs:
       WXT_API_KEY: ${{ secrets.WXT_API_KEY }}
       WXT_API_URL: ${{ secrets.WXT_API_URL }}
       WXT_ARCADE_POINT_URL: ${{ secrets.WXT_ARCADE_POINT_URL }}
+      WXT_ARCADE_POINT_V2_URL: ${{ secrets.WXT_ARCADE_POINT_V2_URL }}
+      WXT_ARCADE_CLIENT_KEY: ${{ secrets.WXT_ARCADE_CLIENT_KEY }}
+      WXT_ARCADE_CLIENT_SECRET: ${{ secrets.WXT_ARCADE_CLIENT_SECRET }}
       WXT_FIREBASE_API_KEY: ${{ secrets.WXT_FIREBASE_API_KEY }}
       WXT_FIREBASE_AUTH_DOMAIN: ${{ secrets.WXT_FIREBASE_AUTH_DOMAIN }}
       WXT_FIREBASE_PROJECT_ID: ${{ secrets.WXT_FIREBASE_PROJECT_ID }}
@@ -84,6 +87,17 @@ jobs:
           fi
 
           git rev-parse --verify "refs/tags/$RELEASE_TAG^{commit}" >/dev/null
+
+      - name: Validate Arcade signing secrets
+        run: |
+          set -euo pipefail
+
+          for name in WXT_ARCADE_CLIENT_KEY WXT_ARCADE_CLIENT_SECRET; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::$name is required for signed Arcade API releases."
+              exit 1
+            fi
+          done
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -178,7 +192,7 @@ jobs:
               --repo "$GITHUB_REPOSITORY" \
               --base main \
               --head "$BRANCH" \
-              --title "docs: update changelog for $RELEASE_TAG" \
+              --title "docs: update CHANGELOG.md for $RELEASE_TAG" \
               --body "Automated CHANGELOG.md update generated from release tag \`$RELEASE_TAG\`.\n\nCreated and merged by @eplus-bot after approval from github-actions[bot] and all required checks pass.")"
             PR_NUMBER="${PR_URL##*/}"
           fi

--- a/services/arcadeApiService.ts
+++ b/services/arcadeApiService.ts
@@ -288,7 +288,10 @@ const ArcadeApiService = {
         url: canonical,
         profileId,
       };
-      const signatureHeaders = await buildArcadeSignatureHeaders(endpoint, payload);
+      const signatureHeaders = await buildArcadeSignatureHeaders(
+        endpoint,
+        payload,
+      );
       const requestConfig = signatureHeaders
         ? { timeout: ARCADE_API_TIMEOUT_MS, headers: signatureHeaders }
         : { timeout: ARCADE_API_TIMEOUT_MS };

--- a/services/arcadeApiService.ts
+++ b/services/arcadeApiService.ts
@@ -7,6 +7,7 @@ import {
   syncFacilitatorRulesFromApi,
 } from "./facilitatorService";
 import { canonicalizeProfileUrl, extractProfileId } from "../utils/profileUrl";
+import { buildArcadeSignatureHeaders } from "../utils/arcadeRequestSignature";
 
 const FACILITATOR_BONUS_LABEL_KEYS: Record<string, string> = {
   1: "milestone1Bonus",
@@ -283,14 +284,15 @@ const ArcadeApiService = {
       // prefer canonical.
       const canonical = canonicalizeProfileUrl(url) || url;
       const profileId = extractProfileId(url);
-      const response = await axios.post(
-        endpoint,
-        {
-          url: canonical,
-          profileId,
-        },
-        { timeout: ARCADE_API_TIMEOUT_MS },
-      );
+      const payload = {
+        url: canonical,
+        profileId,
+      };
+      const signatureHeaders = await buildArcadeSignatureHeaders(endpoint, payload);
+      const requestConfig = signatureHeaders
+        ? { timeout: ARCADE_API_TIMEOUT_MS, headers: signatureHeaders }
+        : { timeout: ARCADE_API_TIMEOUT_MS };
+      const response = await axios.post(endpoint, payload, requestConfig);
 
       if (response.status === 200) {
         const data = response.data as ArcadeData;

--- a/services/arcadeApiService.ts
+++ b/services/arcadeApiService.ts
@@ -62,6 +62,15 @@ function normalizeBadgeCount(value: unknown): number {
   return Number.isFinite(parsed) && parsed >= 0 ? Math.trunc(parsed) : 0;
 }
 
+/** Return a localized UI label when available, otherwise use the fallback. */
+function getLocalizedLabel(key: string, fallback: string): string {
+  try {
+    return browser.i18n.getMessage(key as never) || fallback;
+  } catch (_) {
+    return fallback;
+  }
+}
+
 /**
  * Hide requirements that are not part of the active ruleset without modifying
  * the current count rendered by PopupUIService. The popup owns count rendering;
@@ -87,6 +96,89 @@ function readDisplayedCount(selector: string): number | null {
 }
 
 /**
+ * Add or update one compact metadata row inside a milestone card. This keeps the
+ * extension's existing 2-column layout while exposing the same scoring details
+ * as the web tracker.
+ */
+function upsertMilestoneMetadataRow(
+  details: HTMLElement,
+  rowClass: string,
+  label: string,
+  value: string,
+): void {
+  let row = details.querySelector<HTMLElement>(`.${rowClass}`);
+  if (!row) {
+    row = document.createElement("div");
+    row.className = `flex justify-between ${rowClass}`;
+
+    const labelElement = document.createElement("span");
+    labelElement.className = "text-white/60 facilitator-meta-label";
+    row.append(labelElement);
+
+    const valueElement = document.createElement("span");
+    valueElement.className = "text-white facilitator-meta-value";
+    row.append(valueElement);
+
+    details.append(row);
+  }
+
+  const labelElement = row.querySelector<HTMLElement>(
+    ".facilitator-meta-label",
+  );
+  const valueElement = row.querySelector<HTMLElement>(
+    ".facilitator-meta-value",
+  );
+
+  if (labelElement && labelElement.textContent !== label) {
+    labelElement.textContent = label;
+  }
+  if (valueElement && valueElement.textContent !== value) {
+    valueElement.textContent = value;
+  }
+}
+
+/**
+ * Mirror the web tracker's per-milestone scoring rows: regular Arcade points
+ * required by the milestone and the Facilitator bonus attached to that level.
+ */
+function syncMilestoneMetadata(
+  milestone: string,
+  requirements: {
+    games: number;
+    skills: number;
+    basePoints?: number;
+  },
+): void {
+  const details = document.querySelector<HTMLElement>(
+    `.milestone-card[data-milestone="${milestone}"] .milestone-details`,
+  );
+  if (!details) return;
+
+  const configuredBasePoints = Number(requirements.basePoints);
+  const regularPoints =
+    Number.isFinite(configuredBasePoints) && configuredBasePoints >= 0
+      ? configuredBasePoints
+      : normalizeBadgeCount(requirements.games) +
+        Math.floor(normalizeBadgeCount(requirements.skills) / 2);
+  const bonusPoints = Number(FACILITATOR_MILESTONE_POINTS[milestone] ?? 0);
+  const safeBonusPoints =
+    Number.isFinite(bonusPoints) && bonusPoints >= 0 ? bonusPoints : 0;
+
+  upsertMilestoneMetadataRow(
+    details,
+    `milestone-${milestone}-regular-points-row`,
+    `${getLocalizedLabel("arcadePointsTitle", "Regular Arcade")}:`,
+    formatBonusPoints(regularPoints),
+  );
+  upsertMilestoneMetadataRow(
+    details,
+    `milestone-${milestone}-facilitator-bonus-row`,
+    getLocalizedLabel("facilitatorBonus", "Facilitator bonus:"),
+    `+${formatBonusPoints(safeBonusPoints)}`,
+  );
+}
+
+/**
  * Match the facilitator progress formula used by arcade.eplus.dev: completed
  * badges across active requirements divided by the total badge requirement.
  */
@@ -97,6 +189,7 @@ function syncMilestoneProgress(
     trivia: number;
     skills: number;
     labfree: number;
+    basePoints?: number;
   },
 ): void {
   const requirementEntries = [
@@ -148,7 +241,9 @@ function syncMilestoneProgress(
   );
   if (!progressElement) return;
 
-  const nextText = `${percent}%`;
+  // Keep the percentage first for the compact popup, then expose the same
+  // completed/required total shown by the web tracker (for example 41/42).
+  const nextText = `${percent}% · ${completed}/${total}`;
   if (progressElement.textContent !== nextText) {
     progressElement.textContent = nextText;
   }
@@ -159,6 +254,8 @@ function syncMilestoneProgress(
     "title",
     `Progress: ${percent}% (${completed}/${total} badges completed)\n\n${details.join("\n")}`,
   );
+
+  syncMilestoneMetadata(milestone, requirements);
 }
 
 /**

--- a/utils/arcadeRequestSignature.ts
+++ b/utils/arcadeRequestSignature.ts
@@ -31,7 +31,11 @@ async function hmacSha256Hex(secret: string, value: string): Promise<string> {
     false,
     ["sign"],
   );
-  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(value));
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(value),
+  );
   return toHex(signature);
 }
 

--- a/utils/arcadeRequestSignature.ts
+++ b/utils/arcadeRequestSignature.ts
@@ -1,0 +1,70 @@
+const encoder = new TextEncoder();
+
+function toHex(bytes: ArrayBuffer): string {
+  return Array.from(new Uint8Array(bytes))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function createNonce(): string {
+  if (typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID().replace(/-/g, "");
+  }
+
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(value));
+  return toHex(digest);
+}
+
+async function hmacSha256Hex(secret: string, value: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(value));
+  return toHex(signature);
+}
+
+/**
+ * Build short-lived HMAC headers for the Arcade v2 request.
+ *
+ * The secret is injected only at release-build time. It is not committed to
+ * source control. A timestamp and nonce make copied requests short-lived and
+ * allow the backend to reject replay attempts.
+ */
+export async function buildArcadeSignatureHeaders(
+  endpoint: string,
+  body: unknown,
+): Promise<Record<string, string> | null> {
+  const clientKey = String(import.meta.env.WXT_ARCADE_CLIENT_KEY || "").trim();
+  const clientSecret = String(
+    import.meta.env.WXT_ARCADE_CLIENT_SECRET || "",
+  ).trim();
+
+  if (!clientKey || !clientSecret) return null;
+
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const nonce = createNonce();
+  const rawBody = JSON.stringify(body);
+  const pathname = new URL(endpoint).pathname || "/";
+  const bodyHash = await sha256Hex(rawBody);
+  const canonical = ["POST", pathname, timestamp, nonce, bodyHash].join("\n");
+  const signature = await hmacSha256Hex(clientSecret, canonical);
+
+  return {
+    "X-Arcade-Key": clientKey,
+    "X-Arcade-Timestamp": timestamp,
+    "X-Arcade-Nonce": nonce,
+    "X-Arcade-Signature": signature,
+  };
+}


### PR DESCRIPTION
## What changed

- Sign `/api/v2/arcade` requests with HMAC-SHA256.
- Add short-lived request headers:
  - `X-Arcade-Key`
  - `X-Arcade-Timestamp`
  - `X-Arcade-Nonce`
  - `X-Arcade-Signature`
- Signature covers method + endpoint path + timestamp + nonce + SHA-256 request-body hash.
- Keep dev/tests backward-compatible when signing env vars are absent.
- Require signing secrets in the release workflow so production packages cannot be released unsigned.

## Required GitHub Actions secrets

- `WXT_ARCADE_CLIENT_KEY`
- `WXT_ARCADE_CLIENT_SECRET`
- optional explicit `WXT_ARCADE_POINT_V2_URL`

The key/secret values must match the backend `ARCADE_CLIENT_KEY` / `ARCADE_CLIENT_SECRET` values.

## Security note

A browser extension is a public client, so no embedded/build-time secret can be made permanently undiscoverable. HMAC + timestamp + nonce prevents casual direct calls and replay of captured requests; rotating the release secret and retaining backend rate limiting are still required for stronger abuse resistance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added signed authentication for Arcade API requests.
  * Added validation to prevent releases when required signing credentials are missing.

* **Configuration**
  * Added environment variable placeholders and setup guidance for Arcade client credentials.

* **Release Process**
  * Updated generated changelog pull request naming for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->