### PR TITLE
Fix v1.3.1 Arcade regression tests under release signing env

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,8 +1,10 @@
 import { vi, beforeEach } from "vitest";
 import { fakeBrowser } from "wxt/testing/fake-browser";
 
-// Reset fake browser state between tests
+// Reset fake browser state and release-only signing credentials between tests.
 beforeEach(() => {
   fakeBrowser.reset();
   vi.clearAllMocks();
+  vi.stubEnv("WXT_ARCADE_CLIENT_KEY", "");
+  vi.stubEnv("WXT_ARCADE_CLIENT_SECRET", "");
 });


### PR DESCRIPTION
## Fix

- isolate test suites from release-only `WXT_ARCADE_CLIENT_KEY` / `WXT_ARCADE_CLIENT_SECRET`
- keep existing V2 regression tests on `/api/v2/arcade`
- V3 tests still opt in explicitly by stubbing signing credentials in their own setup
- no runtime Arcade V3 behavior changed

This fixes the 4 failing `arcadeApiService.test.ts` assertions seen after v1.3.1 merge/release.

Do not merge automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by clearing client credentials before each test.
  * Ensured browser state and mocks are consistently reset between tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->