### PR TITLE
Fix false Arcade API failure after successful v3 response

### DIFF
--- a/services/arcadeApiService.ts
+++ b/services/arcadeApiService.ts
@@ -361,41 +361,65 @@ initializeFacilitatorRuleLabelSync();
 const ArcadeApiService = {
   /** Fetch Arcade data exclusively through the signed v3 contract. */
   async fetchArcadeData(url: string): Promise<ArcadeData | null> {
-    try {
-      const endpoint = getArcadeEndpoint();
-      if (!endpoint) return null;
+    const endpoint = getArcadeEndpoint();
+    if (!endpoint) return null;
 
-      const canonical = canonicalizeProfileUrl(url) || url;
-      const profileId = extractProfileId(url);
-      const payload = {
-        url: canonical,
-        profileId,
-      };
+    const canonical = canonicalizeProfileUrl(url) || url;
+    const profileId = extractProfileId(url);
+    const payload = {
+      url: canonical,
+      profileId,
+    };
+
+    let response;
+    try {
       const signatureHeaders = await buildArcadeSignatureHeaders(
         endpoint,
         payload,
       );
-      const response = await axios.post(endpoint, payload, {
+      response = await axios.post(endpoint, payload, {
         timeout: ARCADE_API_TIMEOUT_MS,
         headers: signatureHeaders,
       });
-
-      if (response.status === 200) {
-        const data = response.data as ArcadeData;
-
-        if (!syncFacilitatorRulesFromApi(data.facilitator)) {
-          resetFacilitatorRulesToFallback();
-        }
-        syncFacilitatorRuleLabels();
-
-        data.lastUpdated = new Date().toISOString();
-        return data;
-      }
-
-      return null;
-    } catch {
+    } catch (error) {
+      const details = axios.isAxiosError(error)
+        ? `HTTP ${error.response?.status ?? "network"} (${error.code ?? "unknown"})`
+        : error instanceof Error
+          ? error.message
+          : "Unknown request error";
+      console.debug("[ArcadeApiService] Arcade v3 request failed:", details);
       return null;
     }
+
+    if (
+      response.status !== 200 ||
+      !response.data ||
+      typeof response.data !== "object" ||
+      Array.isArray(response.data) ||
+      response.data.success === false
+    ) {
+      return null;
+    }
+
+    const data: ArcadeData = {
+      ...(response.data as ArcadeData),
+      lastUpdated: new Date().toISOString(),
+    };
+
+    try {
+      if (!syncFacilitatorRulesFromApi(data.facilitator)) {
+        resetFacilitatorRulesToFallback();
+      }
+    } catch (error) {
+      const details =
+        error instanceof Error ? error.message : "Unknown sync error";
+      console.debug(
+        "[ArcadeApiService] Facilitator metadata sync failed:",
+        details,
+      );
+    }
+
+    return data;
   },
 
   /** Validate profile URL format. */

--- a/tests/services/arcadeV3SuccessfulResponse.test.ts
+++ b/tests/services/arcadeV3SuccessfulResponse.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("axios", () => ({
+  default: {
+    post: vi.fn(),
+    isAxiosError: vi.fn(() => false),
+  },
+}));
+
+vi.mock("../../utils/arcadeRequestSignature", () => ({
+  buildArcadeSignatureHeaders: vi.fn(() => Promise.resolve({})),
+}));
+
+vi.mock("../../services/facilitatorService", () => ({
+  FACILITATOR_MILESTONE_POINTS: {
+    1: 5,
+    2: 15,
+    3: 25,
+    ultimate: 35,
+  },
+  FACILITATOR_MILESTONE_REQUIREMENTS: {
+    1: { games: 6, trivia: 0, skills: 18, labfree: 0, basePoints: 15 },
+  },
+  resetFacilitatorRulesToFallback: vi.fn(),
+  syncFacilitatorRulesFromApi: vi.fn(() => {
+    throw new Error("simulated facilitator sync failure");
+  }),
+}));
+
+import axios from "axios";
+import ArcadeApiService from "../../services/arcadeApiService";
+
+describe("ArcadeApiService successful v3 response handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv(
+      "WXT_ARCADE_POINT_URL",
+      "https://private-api.example.test/api/v3/arcade",
+    );
+  });
+
+  it("returns HTTP 200 data even when facilitator post-processing fails", async () => {
+    vi.mocked(axios.post).mockResolvedValueOnce({
+      status: 200,
+      data: Object.freeze({
+        success: true,
+        apiVersion: 3,
+        userDetails: [{ userName: "Test User" }],
+        badges: [],
+      }),
+    });
+
+    const result = await ArcadeApiService.fetchArcadeData(
+      "https://www.skills.google/public_profiles/abc123",
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: true,
+        apiVersion: 3,
+        lastUpdated: expect.any(String),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Root cause

Firefox release logs show the v1.3.2 extension reaches Arcade API v3 with the expected signed headers and the backend returns `success: true`, but the options page can still show `Could not fetch data from API.`

The v1.3.2 client wraps both the HTTP request and all response/UI post-processing in one broad `try/catch`. Any exception after HTTP 200 is therefore converted to `null`, which makes Options incorrectly report an API fetch failure.

## Fix

- keep `WXT_ARCADE_POINT_URL` / API v3 / HMAC behavior unchanged
- separate request failures from successful response processing
- validate and clone a successful v3 JSON response before adding `lastUpdated`
- do not let Facilitator metadata sync failures discard an HTTP 200 response
- remove direct popup DOM label synchronization from the network response path; popup rendering/observer remains responsible for DOM labels
- log only status/error category for diagnostics; no endpoint, key, secret, signature, or payload is logged
- add a regression test proving HTTP 200 data is preserved even when Facilitator post-processing throws

No new extension permissions are added.

Do not merge automatically.