### PR TITLE
Send manual Bonus Milestone flag and use API season scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] - 2026-08-11
+
+### :bug: Bug Fixes
+
+- [`cbef1a3`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/cbef1a3b6c1f0166748eb4e215de6629e2dd908e) - make Arcade client v3-only _(commit by [@hoangsvit](https://github.com/hoangsvit))_
+- [`9e3aeb7`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/9e3aeb70dd316703c9abc80972cb6053875e6384) - require signing for Arcade v3 _(commit by [@hoangsvit](https://github.com/hoangsvit))_
+- [`6db598c`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/6db598cb25b2eaad32638eb4f75d86d9e54ad8fd) - validate Arcade v3-only releases _(commit by [@hoangsvit](https://github.com/hoangsvit))_
+- [`2c54a9b`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/2c54a9ba86543980e9552bd059da6fd28e110bdc) - grant host permission from private Arcade endpoint _(commit by [@hoangsvit](https://github.com/hoangsvit))_
+- [`004133e`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/004133e700e7bf2412cc78aadd4c81e95763c837) - require exact private Arcade v3 endpoint for releases _(commit by [@hoangsvit](https://github.com/hoangsvit))_
+- [`3a04971`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/3a04971688b56ffd68504ba0bc90bbf80d1e1376) - use exact WXT*ARCADE_POINT_URL for Arcade v3 *(commit by [@hoangsvit](https://github.com/hoangsvit))\_
+- [`e677183`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/e67718314aa07d952970e45bbbe883ac725c9f55) - avoid browser console logging in Arcade refresh _(commit by [@hoangsvit](https://github.com/hoangsvit))_
+- [`2e22b3a`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/2e22b3a036b9f697a32eed217ad8a0def52272a9) - load Arcade host permission through WXT manifest env _(commit by [@hoangsvit](https://github.com/hoangsvit))_
+- [`ae86a1a`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/ae86a1a927433385f94af2ee932a0020b3376034) - avoid new Arcade host permission _(commit by [@hoangsvit](https://github.com/hoangsvit))_
+- [`a97199c`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/a97199c92f6cd41327798db8bebaac0f894b4de8) - avoid Arcade host permission in release _(commit by [@hoangsvit](https://github.com/hoangsvit))_
+- [`f7e665a`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/f7e665a8a0480815daa25b109e264575826f3b1f) - restore V3-only flow without new host permissions _(commit by [@hoangsvit](https://github.com/hoangsvit))_
+- [`a9564bf`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/a9564bf637f17a5221a8a985b730c25ff268e4a3) - update version to 1.3.2 in package.json _(commit by [@hoangsvit](https://github.com/hoangsvit))_
+- [`f691d1a`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/f691d1a9eda6840c0419f46dd216e741bec02e8a) - normalize Arcade v3 canonical path _(commit by [@hoangsvit](https://github.com/hoangsvit))_
+- [`b284cc9`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/b284cc99bd8146f6e81c9d8e5cdeb49e0c12a4a6) - keep Arcade refresh errors silent but actionable _(commit by [@hoangsvit](https://github.com/hoangsvit))_
+- [`de11615`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/de116159134da0395ef09839f70e3770f1448a3a) - allow unsigned Arcade v3 requests during rollout _(commit by [@hoangsvit](https://github.com/hoangsvit))_
+- [`f6b95ca`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/f6b95cac80ace38bfa5a9d0c6a2bb1bc60a2e519) - document facilitator label sync callback _(commit by [@hoangsvit](https://github.com/hoangsvit))_
+
+### :white_check_mark: Tests
+
+- [`10280b3`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/10280b34889c56d779774f930865836ef1918628) - cover v3-only Arcade signing _(commit by [@hoangsvit](https://github.com/hoangsvit))_
+- [`8ab21e6`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/8ab21e61b566bff1e9edc7fd4cdd32e0b3411ee3) - run facilitator UI against Arcade v3 _(commit by [@hoangsvit](https://github.com/hoangsvit))_
+- [`eb1b234`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/eb1b234c2be8c07516e38acb74d6ad6020541244) - remove Arcade v2 references _(commit by [@hoangsvit](https://github.com/hoangsvit))_
+- [`bf3b565`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/bf3b5650b852f065a79da59f160be9be50888934) - migrate Arcade service coverage to v3 only _(commit by [@hoangsvit](https://github.com/hoangsvit))_
+- [`d27c4d2`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/d27c4d2a58212b481d0cf1554742c231bd72e27d) - align Arcade v3 mock with error logging _(commit by [@hoangsvit](https://github.com/hoangsvit))_
+- [`d12b5f1`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/d12b5f1a3965668a4ec88d0dcaa36c923c60447e) - require exact Arcade v3 endpoint env _(commit by [@hoangsvit](https://github.com/hoangsvit))_
+- [`2ffc93b`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/2ffc93bce3af112ca77b5aedd8cac7a837836a95) - use exact Arcade v3 endpoint in Facilitator parity _(commit by [@hoangsvit](https://github.com/hoangsvit))_
+- [`e7e0b10`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/e7e0b10856ce8f84c6e163b0f3c3d7360490872d) - use exact WXT*ARCADE_POINT_URL in v3 flow *(commit by [@hoangsvit](https://github.com/hoangsvit))\_
+- [`ba538f9`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/ba538f9dbdecdb1f0e9fee826206ffdad870ed9d) - cover trailing slash HMAC normalization _(commit by [@hoangsvit](https://github.com/hoangsvit))_
+- [`e9e843b`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/e9e843b11a1e41ef5e6e31666a4be54f24d5b08f) - allow unsigned Arcade v3 during rollout _(commit by [@hoangsvit](https://github.com/hoangsvit))_
+- [`6829602`](https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/commit/68296020a8d4d7c05a56df80a31eb3a6b455497e) - keep Arcade v3 fetch active without signing headers _(commit by [@hoangsvit](https://github.com/hoangsvit))_
+
 ## [1.3.1] - 2026-08-11
 
 ### :bug: Bug Fixes
@@ -1286,3 +1321,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.2.15]: https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/compare/1.2.14...1.2.15
 [1.3.0]: https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/compare/1.2.15...1.3.0
 [1.3.1]: https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/compare/1.3.0...1.3.1
+[1.3.2]: https://github.com/ePlus-DEV/google-cloud-skills-boost-helper/compare/1.3.1...1.3.2

--- a/components/BonusMilestoneControl.tsx
+++ b/components/BonusMilestoneControl.tsx
@@ -90,7 +90,7 @@ function BonusMilestoneControl() {
     "",
   );
   const pointsWord = getMessage("textPoints", "points");
-  const reward = `+${state.points} ${pointsWord}`;
+  const reward = `+${state.points.toString()} ${pointsWord}`;
   const disabled = !state.participating || saving;
 
   return (

--- a/components/BonusMilestoneControl.tsx
+++ b/components/BonusMilestoneControl.tsx
@@ -1,4 +1,9 @@
-import { useCallback, useEffect, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type ChangeEvent,
+} from "react";
 import { createRoot, type Root } from "react-dom/client";
 import {
   getBonusMilestoneControlState,
@@ -17,6 +22,7 @@ const EMPTY_STATE: BonusMilestoneControlState = {
   profileUrl: "",
 };
 
+/** Return a localized message while preserving a safe English fallback. */
 function getMessage(key: string, fallback: string): string {
   try {
     return (
@@ -29,6 +35,7 @@ function getMessage(key: string, fallback: string): string {
   }
 }
 
+/** Render the profile-scoped Bonus Milestone self-confirmation control. */
 function BonusMilestoneControl() {
   const [state, setState] = useState<BonusMilestoneControlState>(EMPTY_STATE);
   const [saving, setSaving] = useState(false);
@@ -60,7 +67,7 @@ function BonusMilestoneControl() {
   }, []);
 
   const handleCheckboxChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
+    (event: ChangeEvent<HTMLInputElement>) => {
       void handleChange(event.currentTarget.checked);
     },
     [handleChange],

--- a/components/BonusMilestoneControl.tsx
+++ b/components/BonusMilestoneControl.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState, type ChangeEvent } from "react";
 import { createRoot, type Root } from "react-dom/client";
+import { browser } from "wxt/browser";
 import {
   getBonusMilestoneControlState,
   setActiveBonusMilestoneCompleted,
@@ -35,34 +36,46 @@ function BonusMilestoneControl() {
   const [state, setState] = useState<BonusMilestoneControlState>(EMPTY_STATE);
   const [saving, setSaving] = useState(false);
 
-  const reload = useCallback(async () => {
-    setState(await getBonusMilestoneControlState());
-  }, []);
+  const reload = useCallback(
+    /** Reload the control state from the active profile and API snapshot. */
+    async function reloadControlState() {
+      setState(await getBonusMilestoneControlState());
+    },
+    [],
+  );
 
-  useEffect(() => {
-    void reload();
-    return watchBonusMilestoneControlState(() => {
+  useEffect(
+    /** Load the initial state and subscribe to active-account changes. */
+    function subscribeToBonusMilestoneState() {
       void reload();
-    });
-  }, [reload]);
+      return watchBonusMilestoneControlState(function reloadAfterAccountChange() {
+        void reload();
+      });
+    },
+    [reload],
+  );
 
-  const handleChange = useCallback(async (completed: boolean) => {
-    setState((current) => ({ ...current, completed }));
-    setSaving(true);
+  const handleChange = useCallback(
+    /** Persist one checkbox change and then refresh the signed Arcade request. */
+    async function persistBonusMilestoneChange(completed: boolean) {
+      setSaving(true);
 
-    try {
-      setState(await setActiveBonusMilestoneCompleted(completed));
+      try {
+        setState(await setActiveBonusMilestoneCompleted(completed));
 
-      // Reuse the existing refresh flow so the signed v3 request sends the
-      // self-report and the API returns the season-owned applied bonus points.
-      document.querySelector<HTMLButtonElement>(".refresh-button")?.click();
-    } finally {
-      setSaving(false);
-    }
-  }, []);
+        // Reuse the existing refresh flow so the signed v3 request sends the
+        // self-report and the API returns the season-owned applied bonus points.
+        document.querySelector<HTMLButtonElement>(".refresh-button")?.click();
+      } finally {
+        setSaving(false);
+      }
+    },
+    [],
+  );
 
   const handleCheckboxChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
+    /** Forward the checkbox state to the async persistence handler. */
+    function handleCheckboxEvent(event: ChangeEvent<HTMLInputElement>) {
       void handleChange(event.currentTarget.checked);
     },
     [handleChange],

--- a/components/BonusMilestoneControl.tsx
+++ b/components/BonusMilestoneControl.tsx
@@ -1,9 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useState,
-  type ChangeEvent,
-} from "react";
+import { useCallback, useEffect, useState, type ChangeEvent } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import {
   getBonusMilestoneControlState,

--- a/components/BonusMilestoneControl.tsx
+++ b/components/BonusMilestoneControl.tsx
@@ -44,7 +44,7 @@ function BonusMilestoneControl() {
     });
   }, [reload]);
 
-  const handleChange = async (completed: boolean) => {
+  const handleChange = useCallback(async (completed: boolean) => {
     setState((current) => ({ ...current, completed }));
     setSaving(true);
 
@@ -57,7 +57,14 @@ function BonusMilestoneControl() {
     } finally {
       setSaving(false);
     }
-  };
+  }, []);
+
+  const handleCheckboxChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      void handleChange(event.currentTarget.checked);
+    },
+    [handleChange],
+  );
 
   if (!state.enabled) return null;
 
@@ -88,7 +95,7 @@ function BonusMilestoneControl() {
         aria-label={`${title}: ${reward}`}
         checked={state.completed}
         disabled={disabled}
-        onChange={(event) => void handleChange(event.currentTarget.checked)}
+        onChange={handleCheckboxChange}
       />
     </label>
   );

--- a/components/BonusMilestoneControl.tsx
+++ b/components/BonusMilestoneControl.tsx
@@ -109,7 +109,8 @@ export function mountBonusMilestoneControl(): void {
     host = document.createElement("div");
     host.id = ROOT_ID;
 
-    const milestoneGrid = section.querySelector(".milestone-card")?.parentElement;
+    const milestoneGrid =
+      section.querySelector(".milestone-card")?.parentElement;
     if (milestoneGrid) milestoneGrid.before(host);
     else section.appendChild(host);
 

--- a/components/BonusMilestoneControl.tsx
+++ b/components/BonusMilestoneControl.tsx
@@ -48,9 +48,11 @@ function BonusMilestoneControl() {
     /** Load the initial state and subscribe to active-account changes. */
     function subscribeToBonusMilestoneState() {
       void reload();
-      return watchBonusMilestoneControlState(function reloadAfterAccountChange() {
-        void reload();
-      });
+      return watchBonusMilestoneControlState(
+        function reloadAfterAccountChange() {
+          void reload();
+        },
+      );
     },
     [reload],
   );

--- a/components/BonusMilestoneControl.tsx
+++ b/components/BonusMilestoneControl.tsx
@@ -1,0 +1,120 @@
+import { useCallback, useEffect, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  getBonusMilestoneControlState,
+  setActiveBonusMilestoneCompleted,
+  watchBonusMilestoneControlState,
+  type BonusMilestoneControlState,
+} from "../services/bonusMilestoneService";
+
+const ROOT_ID = "facilitator-bonus-milestone-root";
+
+const EMPTY_STATE: BonusMilestoneControlState = {
+  completed: false,
+  enabled: true,
+  participating: false,
+  points: 10,
+  profileUrl: "",
+};
+
+function getMessage(key: string, fallback: string): string {
+  try {
+    return (
+      browser.i18n.getMessage(
+        key as Parameters<typeof browser.i18n.getMessage>[0],
+      ) || fallback
+    );
+  } catch {
+    return fallback;
+  }
+}
+
+function BonusMilestoneControl() {
+  const [state, setState] = useState<BonusMilestoneControlState>(EMPTY_STATE);
+  const [saving, setSaving] = useState(false);
+
+  const reload = useCallback(async () => {
+    setState(await getBonusMilestoneControlState());
+  }, []);
+
+  useEffect(() => {
+    void reload();
+    return watchBonusMilestoneControlState(() => {
+      void reload();
+    });
+  }, [reload]);
+
+  const handleChange = async (completed: boolean) => {
+    setState((current) => ({ ...current, completed }));
+    setSaving(true);
+
+    try {
+      setState(await setActiveBonusMilestoneCompleted(completed));
+
+      // Reuse the existing refresh flow so the signed v3 request sends the
+      // self-report and the API returns the season-owned applied bonus points.
+      document.querySelector<HTMLButtonElement>(".refresh-button")?.click();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!state.enabled) return null;
+
+  const title = getMessage("facilitatorBonus", "Facilitator Bonus").replace(
+    /[:：]\s*$/u,
+    "",
+  );
+  const pointsWord = getMessage("textPoints", "points");
+  const reward = `+${state.points} ${pointsWord}`;
+  const disabled = !state.participating || saving;
+
+  return (
+    <label
+      className={`flex items-center justify-between gap-3 bg-emerald-500/10 backdrop-blur-md rounded-lg p-3 mb-3 border border-emerald-400/30 ${
+        disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"
+      }`}
+    >
+      <span className="flex items-center min-w-0">
+        <i className="fa-solid fa-circle-check text-emerald-400 text-lg mr-2" />
+        <span className="min-w-0">
+          <strong className="block text-white text-sm">{title}</strong>
+          <small className="block text-emerald-300/70 text-xs">{reward}</small>
+        </span>
+      </span>
+      <input
+        type="checkbox"
+        className="h-5 w-5 accent-emerald-500"
+        aria-label={`${title}: ${reward}`}
+        checked={state.completed}
+        disabled={disabled}
+        onChange={(event) => void handleChange(event.currentTarget.checked)}
+      />
+    </label>
+  );
+}
+
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+
+/** Mount exactly one React root into the existing popup milestone section. */
+export function mountBonusMilestoneControl(): void {
+  const section = document.getElementById("milestones-section");
+  if (!section) return;
+
+  if (!host?.isConnected) {
+    const existing = document.getElementById(ROOT_ID);
+    if (existing) existing.remove();
+
+    host = document.createElement("div");
+    host.id = ROOT_ID;
+
+    const milestoneGrid = section.querySelector(".milestone-card")?.parentElement;
+    if (milestoneGrid) milestoneGrid.before(host);
+    else section.appendChild(host);
+
+    root = createRoot(host);
+  }
+
+  root?.render(<BonusMilestoneControl />);
+}

--- a/entrypoints/popup/bonusMilestoneControl.tsx
+++ b/entrypoints/popup/bonusMilestoneControl.tsx
@@ -1,0 +1,15 @@
+import { mountBonusMilestoneControl } from "../../components/BonusMilestoneControl";
+
+/** Mount the Bonus Milestone React control after the popup DOM is available. */
+function initializeBonusMilestoneControl(): void {
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", mountBonusMilestoneControl, {
+      once: true,
+    });
+    return;
+  }
+
+  mountBonusMilestoneControl();
+}
+
+initializeBonusMilestoneControl();

--- a/services/bonusMilestoneService.ts
+++ b/services/bonusMilestoneService.ts
@@ -82,11 +82,14 @@ async function syncPopupControl(): Promise<void> {
       <input type="checkbox" class="h-5 w-5 accent-emerald-500" aria-label="Bonus Milestone +10" />
     `;
 
-    const milestoneGrid = section.querySelector(".milestone-card")?.parentElement;
+    const milestoneGrid =
+      section.querySelector(".milestone-card")?.parentElement;
     if (milestoneGrid) milestoneGrid.before(control);
     else section.appendChild(control);
 
-    const checkbox = control.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    const checkbox = control.querySelector<HTMLInputElement>(
+      'input[type="checkbox"]',
+    );
     checkbox?.addEventListener("change", async () => {
       const current = await AccountService.getActiveAccount();
       if (!current?.profileUrl || !checkbox) return;
@@ -95,12 +98,15 @@ async function syncPopupControl(): Promise<void> {
 
       // Reuse the existing refresh flow so the signed API recalculates the total
       // immediately instead of maintaining a second scoring implementation here.
-      const refreshButton = document.querySelector<HTMLButtonElement>(".refresh-button");
+      const refreshButton =
+        document.querySelector<HTMLButtonElement>(".refresh-button");
       refreshButton?.click();
     });
   }
 
-  const checkbox = control.querySelector<HTMLInputElement>('input[type="checkbox"]');
+  const checkbox = control.querySelector<HTMLInputElement>(
+    'input[type="checkbox"]',
+  );
   if (!checkbox) return;
 
   const participating = Boolean(activeAccount?.facilitatorProgram);

--- a/services/bonusMilestoneService.ts
+++ b/services/bonusMilestoneService.ts
@@ -1,4 +1,4 @@
-import type { Account, ArcadeData } from "../types";
+import type { ArcadeData } from "../types";
 import { canonicalizeProfileUrl, extractProfileId } from "../utils/profileUrl";
 import AccountService from "./accountService";
 
@@ -32,10 +32,7 @@ export async function setBonusMilestoneCompleted(
   await storage.setItem(storageKey(profileUrl), Boolean(completed));
 }
 
-/**
- * Read the API-advertised manual Bonus Milestone value. The API never decides
- * whether it is completed; that remains a per-profile local confirmation.
- */
+/** Read the API-owned Bonus Milestone amount, with +10 only for old responses. */
 export function getBonusMilestoneAvailablePoints(
   arcadeData?: ArcadeData | null,
 ): number {
@@ -45,32 +42,10 @@ export function getBonusMilestoneAvailablePoints(
     : DEFAULT_BONUS_MILESTONE_POINTS;
 }
 
-async function applyManualBonusToAccount(
-  account: Account | null,
-  participating: boolean,
-  completed: boolean,
-  points: number,
-): Promise<ArcadeData | null> {
-  if (!account?.arcadeData?.faciCounts) return null;
-
-  const desiredPoints = participating && completed ? points : 0;
-  if (
-    Number(account.arcadeData.faciCounts.manualBonusMilestonePoints ?? 0) ===
-    desiredPoints
-  ) {
-    return null;
-  }
-
-  const arcadeData: ArcadeData = {
-    ...account.arcadeData,
-    faciCounts: {
-      ...account.arcadeData.faciCounts,
-      manualBonusMilestonePoints: desiredPoints,
-    },
-  };
-
-  await AccountService.updateAccountArcadeData(account.id, arcadeData);
-  return arcadeData;
+/** Old API responses did not expose availability, so keep the current control visible. */
+export function isBonusMilestoneEnabled(arcadeData?: ArcadeData | null): boolean {
+  const value = arcadeData?.facilitator?.bonusMilestoneEnabled;
+  return typeof value === "boolean" ? value : true;
 }
 
 async function syncPopupControl(): Promise<void> {
@@ -110,7 +85,14 @@ async function syncPopupControl(): Promise<void> {
       if (!current?.profileUrl || !checkbox) return;
 
       await setBonusMilestoneCompleted(current.profileUrl, checkbox.checked);
-      await syncPopupControl();
+
+      // The API owns season availability and point values. Reuse the normal
+      // refresh flow so the next signed request sends only the self-report flag
+      // and all score surfaces consume the API-calculated Bonus Milestone amount.
+      const refreshButton =
+        document.querySelector<HTMLButtonElement>(".refresh-button");
+      if (refreshButton) refreshButton.click();
+      else await syncPopupControl();
     });
   }
 
@@ -119,6 +101,7 @@ async function syncPopupControl(): Promise<void> {
   );
   if (!checkbox) return;
 
+  const enabled = isBonusMilestoneEnabled(activeAccount?.arcadeData);
   const points = getBonusMilestoneAvailablePoints(activeAccount?.arcadeData);
   const pointsLabel = control.querySelector<HTMLElement>(
     ".bonus-milestone-points",
@@ -128,28 +111,18 @@ async function syncPopupControl(): Promise<void> {
 
   const participating = Boolean(activeAccount?.facilitatorProgram);
   const completed =
-    participating && Boolean(activeAccount?.profileUrl)
+    participating && enabled && Boolean(activeAccount?.profileUrl)
       ? await isBonusMilestoneCompleted(activeAccount?.profileUrl || "")
       : false;
 
-  checkbox.disabled = !participating;
+  control.hidden = !enabled;
+  checkbox.disabled = !participating || !enabled;
   checkbox.checked = completed;
   control.classList.toggle("opacity-50", !participating);
-  control.classList.toggle("cursor-not-allowed", !participating);
-
-  const updatedArcadeData = await applyManualBonusToAccount(
-    activeAccount,
-    participating,
-    completed,
-    points,
-  );
-  if (updatedArcadeData) {
-    const { default: PopupUIService } = await import("./popupUIService");
-    await PopupUIService.updateMainUI(updatedArcadeData, participating);
-  }
+  control.classList.toggle("cursor-not-allowed", !participating || !enabled);
 }
 
-/** Install the popup-only control without affecting the normal API request. */
+/** Install the popup-only self-confirmation control. */
 export function initializeBonusMilestoneControl(): void {
   if (typeof document === "undefined") return;
 

--- a/services/bonusMilestoneService.ts
+++ b/services/bonusMilestoneService.ts
@@ -1,13 +1,10 @@
-import AccountService from "./accountService";
+import type { ArcadeData } from "../types";
 import { canonicalizeProfileUrl, extractProfileId } from "../utils/profileUrl";
+import AccountService from "./accountService";
 
 const STORAGE_PREFIX = "local:facilitatorBonusMilestone";
 const CONTROL_ID = "facilitator-bonus-milestone-control";
-
-type FacilitatorScoringContext = {
-  participating: boolean;
-  bonusMilestoneCompleted: boolean;
-};
+export const DEFAULT_BONUS_MILESTONE_POINTS = 10;
 
 function storageKey(profileUrl: string): `local:${string}` {
   const canonical = canonicalizeProfileUrl(profileUrl) || profileUrl.trim();
@@ -36,26 +33,16 @@ export async function setBonusMilestoneCompleted(
 }
 
 /**
- * Resolve the score context for the account matching a requested profile URL.
- * This works for active-account refreshes and for updating a non-active account
- * from the options page. Tests/background startup may not expose WXT storage yet,
- * so unavailable account state safely falls back to no Facilitator bonus.
+ * Read the API-advertised manual Bonus Milestone value. The API never decides
+ * whether it is completed; that remains a per-profile local confirmation.
  */
-export async function getFacilitatorScoringContext(
-  profileUrl: string,
-): Promise<FacilitatorScoringContext> {
-  try {
-    const canonical = canonicalizeProfileUrl(profileUrl) || profileUrl;
-    const account = await AccountService.isAccountExists(canonical);
-    const participating = Boolean(account?.facilitatorProgram);
-    const bonusMilestoneCompleted = participating
-      ? await isBonusMilestoneCompleted(canonical)
-      : false;
-
-    return { participating, bonusMilestoneCompleted };
-  } catch {
-    return { participating: false, bonusMilestoneCompleted: false };
-  }
+export function getBonusMilestoneAvailablePoints(
+  arcadeData?: ArcadeData | null,
+): number {
+  const value = Number(arcadeData?.facilitator?.bonusMilestoneAvailablePoints);
+  return Number.isFinite(value) && value >= 0
+    ? value
+    : DEFAULT_BONUS_MILESTONE_POINTS;
 }
 
 async function syncPopupControl(): Promise<void> {
@@ -76,7 +63,7 @@ async function syncPopupControl(): Promise<void> {
         <i class="fa-solid fa-circle-check text-emerald-400 text-lg mr-2"></i>
         <span class="min-w-0">
           <strong class="block text-white text-sm">Bonus Milestone</strong>
-          <small class="block text-emerald-300/70 text-xs">+10</small>
+          <small class="block text-emerald-300/70 text-xs bonus-milestone-points">+10</small>
         </span>
       </span>
       <input type="checkbox" class="h-5 w-5 accent-emerald-500" aria-label="Bonus Milestone +10" />
@@ -96,8 +83,8 @@ async function syncPopupControl(): Promise<void> {
 
       await setBonusMilestoneCompleted(current.profileUrl, checkbox.checked);
 
-      // Reuse the existing refresh flow so the signed API recalculates the total
-      // immediately instead of maintaining a second scoring implementation here.
+      // Use the normal refresh path. The request body stays unchanged; after the
+      // response arrives ArcadeApiService re-attaches this local manual +10 state.
       const refreshButton =
         document.querySelector<HTMLButtonElement>(".refresh-button");
       refreshButton?.click();
@@ -108,6 +95,13 @@ async function syncPopupControl(): Promise<void> {
     'input[type="checkbox"]',
   );
   if (!checkbox) return;
+
+  const points = getBonusMilestoneAvailablePoints(activeAccount?.arcadeData);
+  const pointsLabel = control.querySelector<HTMLElement>(
+    ".bonus-milestone-points",
+  );
+  if (pointsLabel) pointsLabel.textContent = `+${points}`;
+  checkbox.setAttribute("aria-label", `Bonus Milestone +${points}`);
 
   const participating = Boolean(activeAccount?.facilitatorProgram);
   checkbox.disabled = !participating;

--- a/services/bonusMilestoneService.ts
+++ b/services/bonusMilestoneService.ts
@@ -1,3 +1,4 @@
+import { storage } from "wxt/utils/storage";
 import type { AccountsData, ArcadeData } from "../types";
 import { canonicalizeProfileUrl, extractProfileId } from "../utils/profileUrl";
 import AccountService from "./accountService";
@@ -96,27 +97,37 @@ export async function setActiveBonusMilestoneCompleted(
 export function watchBonusMilestoneControlState(
   listener: () => void,
 ): () => void {
-  return storage.watch<AccountsData>("local:accountsData", () => listener());
+  return storage.watch<AccountsData>("local:accountsData", listener);
+}
+
+/** Dynamically load and mount the React control only inside the popup document. */
+async function mountPopupControl(): Promise<void> {
+  if (!document.getElementById("popup-content")) return;
+
+  const { mountBonusMilestoneControl } = await import(
+    "../components/BonusMilestoneControl"
+  );
+  mountBonusMilestoneControl();
+}
+
+/** Start the asynchronous popup mount without leaking a floating promise. */
+function startPopupControlMount(): void {
+  void mountPopupControl();
 }
 
 /**
  * Mount the popup-only React control when this module is used from the popup.
- * Rendering and lifecycle are intentionally kept out of this service module.
+ * Rendering and state lifecycle stay inside the React component.
  */
 function initializePopupControlMount(): void {
   if (typeof document === "undefined") return;
 
-  const mount = () => {
-    if (!document.getElementById("popup-content")) return;
-    void import("../components/BonusMilestoneControl").then(
-      ({ mountBonusMilestoneControl }) => mountBonusMilestoneControl(),
-    );
-  };
-
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", mount, { once: true });
+    document.addEventListener("DOMContentLoaded", startPopupControlMount, {
+      once: true,
+    });
   } else {
-    mount();
+    startPopupControlMount();
   }
 }
 

--- a/services/bonusMilestoneService.ts
+++ b/services/bonusMilestoneService.ts
@@ -104,9 +104,8 @@ export function watchBonusMilestoneControlState(
 async function mountPopupControl(): Promise<void> {
   if (!document.getElementById("popup-content")) return;
 
-  const { mountBonusMilestoneControl } = await import(
-    "../components/BonusMilestoneControl"
-  );
+  const { mountBonusMilestoneControl } =
+    await import("../components/BonusMilestoneControl");
   mountBonusMilestoneControl();
 }
 

--- a/services/bonusMilestoneService.ts
+++ b/services/bonusMilestoneService.ts
@@ -1,0 +1,133 @@
+import AccountService from "./accountService";
+import { canonicalizeProfileUrl, extractProfileId } from "../utils/profileUrl";
+
+const STORAGE_PREFIX = "local:facilitatorBonusMilestone";
+const CONTROL_ID = "facilitator-bonus-milestone-control";
+
+type FacilitatorScoringContext = {
+  participating: boolean;
+  bonusMilestoneCompleted: boolean;
+};
+
+function storageKey(profileUrl: string): `local:${string}` {
+  const canonical = canonicalizeProfileUrl(profileUrl) || profileUrl.trim();
+  const profileId = extractProfileId(canonical);
+  const identity = profileId || encodeURIComponent(canonical.toLowerCase());
+  return `${STORAGE_PREFIX}:${identity}` as `local:${string}`;
+}
+
+export async function isBonusMilestoneCompleted(
+  profileUrl: string,
+): Promise<boolean> {
+  if (!profileUrl) return false;
+  try {
+    return Boolean(await storage.getItem<boolean>(storageKey(profileUrl)));
+  } catch {
+    return false;
+  }
+}
+
+export async function setBonusMilestoneCompleted(
+  profileUrl: string,
+  completed: boolean,
+): Promise<void> {
+  if (!profileUrl) return;
+  await storage.setItem(storageKey(profileUrl), Boolean(completed));
+}
+
+/**
+ * Resolve the score context for the account matching a requested profile URL.
+ * This works for active-account refreshes and for updating a non-active account
+ * from the options page.
+ */
+export async function getFacilitatorScoringContext(
+  profileUrl: string,
+): Promise<FacilitatorScoringContext> {
+  const canonical = canonicalizeProfileUrl(profileUrl) || profileUrl;
+  const account = await AccountService.isAccountExists(canonical);
+  const participating = Boolean(account?.facilitatorProgram);
+  const bonusMilestoneCompleted = participating
+    ? await isBonusMilestoneCompleted(canonical)
+    : false;
+
+  return { participating, bonusMilestoneCompleted };
+}
+
+async function syncPopupControl(): Promise<void> {
+  if (typeof document === "undefined") return;
+  const section = document.getElementById("milestones-section");
+  if (!section) return;
+
+  const activeAccount = await AccountService.getActiveAccount();
+  let control = document.getElementById(CONTROL_ID) as HTMLLabelElement | null;
+
+  if (!control) {
+    control = document.createElement("label");
+    control.id = CONTROL_ID;
+    control.className =
+      "flex items-center justify-between gap-3 bg-emerald-500/10 backdrop-blur-md rounded-lg p-3 mb-3 border border-emerald-400/30 cursor-pointer";
+    control.innerHTML = `
+      <span class="flex items-center min-w-0">
+        <i class="fa-solid fa-circle-check text-emerald-400 text-lg mr-2"></i>
+        <span class="min-w-0">
+          <strong class="block text-white text-sm">Bonus Milestone</strong>
+          <small class="block text-emerald-300/70 text-xs">+10</small>
+        </span>
+      </span>
+      <input type="checkbox" class="h-5 w-5 accent-emerald-500" aria-label="Bonus Milestone +10" />
+    `;
+
+    const milestoneGrid = section.querySelector(".milestone-card")?.parentElement;
+    if (milestoneGrid) milestoneGrid.before(control);
+    else section.appendChild(control);
+
+    const checkbox = control.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    checkbox?.addEventListener("change", async () => {
+      const current = await AccountService.getActiveAccount();
+      if (!current?.profileUrl || !checkbox) return;
+
+      await setBonusMilestoneCompleted(current.profileUrl, checkbox.checked);
+
+      // Reuse the existing refresh flow so the signed API recalculates the total
+      // immediately instead of maintaining a second scoring implementation here.
+      const refreshButton = document.querySelector<HTMLButtonElement>(".refresh-button");
+      refreshButton?.click();
+    });
+  }
+
+  const checkbox = control.querySelector<HTMLInputElement>('input[type="checkbox"]');
+  if (!checkbox) return;
+
+  const participating = Boolean(activeAccount?.facilitatorProgram);
+  checkbox.disabled = !participating;
+  control.classList.toggle("opacity-50", !participating);
+  control.classList.toggle("cursor-not-allowed", !participating);
+
+  checkbox.checked =
+    participating && Boolean(activeAccount?.profileUrl)
+      ? await isBonusMilestoneCompleted(activeAccount?.profileUrl || "")
+      : false;
+}
+
+/** Install the popup-only control without affecting background/options pages. */
+export function initializeBonusMilestoneControl(): void {
+  if (typeof document === "undefined") return;
+
+  const install = () => {
+    if (!document.getElementById("popup-content")) return;
+    void syncPopupControl();
+
+    const observer = new MutationObserver(() => {
+      void syncPopupControl();
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", install, { once: true });
+  } else {
+    install();
+  }
+}
+
+initializeBonusMilestoneControl();

--- a/services/bonusMilestoneService.ts
+++ b/services/bonusMilestoneService.ts
@@ -1,4 +1,4 @@
-import type { ArcadeData } from "../types";
+import type { Account, ArcadeData } from "../types";
 import { canonicalizeProfileUrl, extractProfileId } from "../utils/profileUrl";
 import AccountService from "./accountService";
 
@@ -48,6 +48,35 @@ export function isBonusMilestoneEnabled(arcadeData?: ArcadeData | null): boolean
   return typeof value === "boolean" ? value : true;
 }
 
+/**
+ * Copy the API-calculated self-reported Bonus Milestone amount into faciCounts,
+ * which is the existing shared score input used by popup/options surfaces.
+ */
+async function applyApiBonusToAccount(
+  account: Account | null,
+): Promise<ArcadeData | null> {
+  if (!account?.arcadeData?.faciCounts) return null;
+
+  const rawPoints = Number(account.arcadeData.facilitator?.bonusMilestonePoints);
+  const apiPoints = Number.isFinite(rawPoints) && rawPoints >= 0 ? rawPoints : 0;
+  const currentPoints = Number(account.arcadeData.faciCounts.bonusMilestonePoints);
+
+  if (Number.isFinite(currentPoints) && currentPoints === apiPoints) {
+    return null;
+  }
+
+  const arcadeData: ArcadeData = {
+    ...account.arcadeData,
+    faciCounts: {
+      ...account.arcadeData.faciCounts,
+      bonusMilestonePoints: apiPoints,
+    },
+  };
+
+  await AccountService.updateAccountArcadeData(account.id, arcadeData);
+  return arcadeData;
+}
+
 async function syncPopupControl(): Promise<void> {
   if (typeof document === "undefined") return;
   const section = document.getElementById("milestones-section");
@@ -87,8 +116,7 @@ async function syncPopupControl(): Promise<void> {
       await setBonusMilestoneCompleted(current.profileUrl, checkbox.checked);
 
       // The API owns season availability and point values. Reuse the normal
-      // refresh flow so the next signed request sends only the self-report flag
-      // and all score surfaces consume the API-calculated Bonus Milestone amount.
+      // refresh flow so the signed request sends only the self-report flag.
       const refreshButton =
         document.querySelector<HTMLButtonElement>(".refresh-button");
       if (refreshButton) refreshButton.click();
@@ -120,6 +148,12 @@ async function syncPopupControl(): Promise<void> {
   checkbox.checked = completed;
   control.classList.toggle("opacity-50", !participating);
   control.classList.toggle("cursor-not-allowed", !participating || !enabled);
+
+  const updatedArcadeData = await applyApiBonusToAccount(activeAccount);
+  if (updatedArcadeData) {
+    const { default: PopupUIService } = await import("./popupUIService");
+    await PopupUIService.updateMainUI(updatedArcadeData, participating);
+  }
 }
 
 /** Install the popup-only self-confirmation control. */

--- a/services/bonusMilestoneService.ts
+++ b/services/bonusMilestoneService.ts
@@ -1,4 +1,4 @@
-import type { ArcadeData } from "../types";
+import type { Account, ArcadeData } from "../types";
 import { canonicalizeProfileUrl, extractProfileId } from "../utils/profileUrl";
 import AccountService from "./accountService";
 
@@ -45,6 +45,34 @@ export function getBonusMilestoneAvailablePoints(
     : DEFAULT_BONUS_MILESTONE_POINTS;
 }
 
+async function applyManualBonusToAccount(
+  account: Account | null,
+  participating: boolean,
+  completed: boolean,
+  points: number,
+): Promise<ArcadeData | null> {
+  if (!account?.arcadeData?.faciCounts) return null;
+
+  const desiredPoints = participating && completed ? points : 0;
+  if (
+    Number(account.arcadeData.faciCounts.manualBonusMilestonePoints ?? 0) ===
+    desiredPoints
+  ) {
+    return null;
+  }
+
+  const arcadeData: ArcadeData = {
+    ...account.arcadeData,
+    faciCounts: {
+      ...account.arcadeData.faciCounts,
+      manualBonusMilestonePoints: desiredPoints,
+    },
+  };
+
+  await AccountService.updateAccountArcadeData(account.id, arcadeData);
+  return arcadeData;
+}
+
 async function syncPopupControl(): Promise<void> {
   if (typeof document === "undefined") return;
   const section = document.getElementById("milestones-section");
@@ -82,12 +110,7 @@ async function syncPopupControl(): Promise<void> {
       if (!current?.profileUrl || !checkbox) return;
 
       await setBonusMilestoneCompleted(current.profileUrl, checkbox.checked);
-
-      // Use the normal refresh path. The request body stays unchanged; after the
-      // response arrives ArcadeApiService re-attaches this local manual +10 state.
-      const refreshButton =
-        document.querySelector<HTMLButtonElement>(".refresh-button");
-      refreshButton?.click();
+      await syncPopupControl();
     });
   }
 
@@ -104,17 +127,29 @@ async function syncPopupControl(): Promise<void> {
   checkbox.setAttribute("aria-label", `Bonus Milestone +${points}`);
 
   const participating = Boolean(activeAccount?.facilitatorProgram);
-  checkbox.disabled = !participating;
-  control.classList.toggle("opacity-50", !participating);
-  control.classList.toggle("cursor-not-allowed", !participating);
-
-  checkbox.checked =
+  const completed =
     participating && Boolean(activeAccount?.profileUrl)
       ? await isBonusMilestoneCompleted(activeAccount?.profileUrl || "")
       : false;
+
+  checkbox.disabled = !participating;
+  checkbox.checked = completed;
+  control.classList.toggle("opacity-50", !participating);
+  control.classList.toggle("cursor-not-allowed", !participating);
+
+  const updatedArcadeData = await applyManualBonusToAccount(
+    activeAccount,
+    participating,
+    completed,
+    points,
+  );
+  if (updatedArcadeData) {
+    const { default: PopupUIService } = await import("./popupUIService");
+    await PopupUIService.updateMainUI(updatedArcadeData, participating);
+  }
 }
 
-/** Install the popup-only control without affecting background/options pages. */
+/** Install the popup-only control without affecting the normal API request. */
 export function initializeBonusMilestoneControl(): void {
   if (typeof document === "undefined") return;
 

--- a/services/bonusMilestoneService.ts
+++ b/services/bonusMilestoneService.ts
@@ -43,7 +43,9 @@ export function getBonusMilestoneAvailablePoints(
 }
 
 /** Old API responses did not expose availability, so keep the current control visible. */
-export function isBonusMilestoneEnabled(arcadeData?: ArcadeData | null): boolean {
+export function isBonusMilestoneEnabled(
+  arcadeData?: ArcadeData | null,
+): boolean {
   const value = arcadeData?.facilitator?.bonusMilestoneEnabled;
   return typeof value === "boolean" ? value : true;
 }
@@ -57,9 +59,14 @@ async function applyApiBonusToAccount(
 ): Promise<ArcadeData | null> {
   if (!account?.arcadeData?.faciCounts) return null;
 
-  const rawPoints = Number(account.arcadeData.facilitator?.bonusMilestonePoints);
-  const apiPoints = Number.isFinite(rawPoints) && rawPoints >= 0 ? rawPoints : 0;
-  const currentPoints = Number(account.arcadeData.faciCounts.bonusMilestonePoints);
+  const rawPoints = Number(
+    account.arcadeData.facilitator?.bonusMilestonePoints,
+  );
+  const apiPoints =
+    Number.isFinite(rawPoints) && rawPoints >= 0 ? rawPoints : 0;
+  const currentPoints = Number(
+    account.arcadeData.faciCounts.bonusMilestonePoints,
+  );
 
   if (Number.isFinite(currentPoints) && currentPoints === apiPoints) {
     return null;

--- a/services/bonusMilestoneService.ts
+++ b/services/bonusMilestoneService.ts
@@ -1,4 +1,4 @@
-import type { Account, ArcadeData } from "../types";
+import type { ArcadeData } from "../types";
 import { canonicalizeProfileUrl, extractProfileId } from "../utils/profileUrl";
 import AccountService from "./accountService";
 
@@ -50,40 +50,6 @@ export function isBonusMilestoneEnabled(
   return typeof value === "boolean" ? value : true;
 }
 
-/**
- * Copy the API-calculated self-reported Bonus Milestone amount into faciCounts,
- * which is the existing shared score input used by popup/options surfaces.
- */
-async function applyApiBonusToAccount(
-  account: Account | null,
-): Promise<ArcadeData | null> {
-  if (!account?.arcadeData?.faciCounts) return null;
-
-  const rawPoints = Number(
-    account.arcadeData.facilitator?.bonusMilestonePoints,
-  );
-  const apiPoints =
-    Number.isFinite(rawPoints) && rawPoints >= 0 ? rawPoints : 0;
-  const currentPoints = Number(
-    account.arcadeData.faciCounts.bonusMilestonePoints,
-  );
-
-  if (Number.isFinite(currentPoints) && currentPoints === apiPoints) {
-    return null;
-  }
-
-  const arcadeData: ArcadeData = {
-    ...account.arcadeData,
-    faciCounts: {
-      ...account.arcadeData.faciCounts,
-      bonusMilestonePoints: apiPoints,
-    },
-  };
-
-  await AccountService.updateAccountArcadeData(account.id, arcadeData);
-  return arcadeData;
-}
-
 async function syncPopupControl(): Promise<void> {
   if (typeof document === "undefined") return;
   const section = document.getElementById("milestones-section");
@@ -123,7 +89,8 @@ async function syncPopupControl(): Promise<void> {
       await setBonusMilestoneCompleted(current.profileUrl, checkbox.checked);
 
       // The API owns season availability and point values. Reuse the normal
-      // refresh flow so the signed request sends only the self-report flag.
+      // refresh flow so the signed request sends only the self-report flag and
+      // faciCounts.bonusMilestonePoints comes back from the API response.
       const refreshButton =
         document.querySelector<HTMLButtonElement>(".refresh-button");
       if (refreshButton) refreshButton.click();
@@ -155,12 +122,6 @@ async function syncPopupControl(): Promise<void> {
   checkbox.checked = completed;
   control.classList.toggle("opacity-50", !participating);
   control.classList.toggle("cursor-not-allowed", !participating || !enabled);
-
-  const updatedArcadeData = await applyApiBonusToAccount(activeAccount);
-  if (updatedArcadeData) {
-    const { default: PopupUIService } = await import("./popupUIService");
-    await PopupUIService.updateMainUI(updatedArcadeData, participating);
-  }
 }
 
 /** Install the popup-only self-confirmation control. */

--- a/services/bonusMilestoneService.ts
+++ b/services/bonusMilestoneService.ts
@@ -1,10 +1,17 @@
-import type { ArcadeData } from "../types";
+import type { AccountsData, ArcadeData } from "../types";
 import { canonicalizeProfileUrl, extractProfileId } from "../utils/profileUrl";
 import AccountService from "./accountService";
 
 const STORAGE_PREFIX = "local:facilitatorBonusMilestone";
-const CONTROL_ID = "facilitator-bonus-milestone-control";
 export const DEFAULT_BONUS_MILESTONE_POINTS = 10;
+
+export type BonusMilestoneControlState = {
+  completed: boolean;
+  enabled: boolean;
+  participating: boolean;
+  points: number;
+  profileUrl: string;
+};
 
 function storageKey(profileUrl: string): `local:${string}` {
   const canonical = canonicalizeProfileUrl(profileUrl) || profileUrl.trim();
@@ -50,99 +57,64 @@ export function isBonusMilestoneEnabled(
   return typeof value === "boolean" ? value : true;
 }
 
-async function syncPopupControl(): Promise<void> {
-  if (typeof document === "undefined") return;
-  const section = document.getElementById("milestones-section");
-  if (!section) return;
-
+/** Resolve all state required by the popup control without rendering any UI. */
+export async function getBonusMilestoneControlState(): Promise<BonusMilestoneControlState> {
   const activeAccount = await AccountService.getActiveAccount();
-  let control = document.getElementById(CONTROL_ID) as HTMLLabelElement | null;
-
-  if (!control) {
-    control = document.createElement("label");
-    control.id = CONTROL_ID;
-    control.className =
-      "flex items-center justify-between gap-3 bg-emerald-500/10 backdrop-blur-md rounded-lg p-3 mb-3 border border-emerald-400/30 cursor-pointer";
-    control.innerHTML = `
-      <span class="flex items-center min-w-0">
-        <i class="fa-solid fa-circle-check text-emerald-400 text-lg mr-2"></i>
-        <span class="min-w-0">
-          <strong class="block text-white text-sm">Bonus Milestone</strong>
-          <small class="block text-emerald-300/70 text-xs bonus-milestone-points">+10</small>
-        </span>
-      </span>
-      <input type="checkbox" class="h-5 w-5 accent-emerald-500" aria-label="Bonus Milestone +10" />
-    `;
-
-    const milestoneGrid =
-      section.querySelector(".milestone-card")?.parentElement;
-    if (milestoneGrid) milestoneGrid.before(control);
-    else section.appendChild(control);
-
-    const checkbox = control.querySelector<HTMLInputElement>(
-      'input[type="checkbox"]',
-    );
-    checkbox?.addEventListener("change", async () => {
-      const current = await AccountService.getActiveAccount();
-      if (!current?.profileUrl || !checkbox) return;
-
-      await setBonusMilestoneCompleted(current.profileUrl, checkbox.checked);
-
-      // The API owns season availability and point values. Reuse the normal
-      // refresh flow so the signed request sends only the self-report flag and
-      // faciCounts.bonusMilestonePoints comes back from the API response.
-      const refreshButton =
-        document.querySelector<HTMLButtonElement>(".refresh-button");
-      if (refreshButton) refreshButton.click();
-      else await syncPopupControl();
-    });
-  }
-
-  const checkbox = control.querySelector<HTMLInputElement>(
-    'input[type="checkbox"]',
-  );
-  if (!checkbox) return;
-
+  const profileUrl = activeAccount?.profileUrl || "";
   const enabled = isBonusMilestoneEnabled(activeAccount?.arcadeData);
-  const points = getBonusMilestoneAvailablePoints(activeAccount?.arcadeData);
-  const pointsLabel = control.querySelector<HTMLElement>(
-    ".bonus-milestone-points",
-  );
-  if (pointsLabel) pointsLabel.textContent = `+${points}`;
-  checkbox.setAttribute("aria-label", `Bonus Milestone +${points}`);
-
   const participating = Boolean(activeAccount?.facilitatorProgram);
+  const points = getBonusMilestoneAvailablePoints(activeAccount?.arcadeData);
   const completed =
-    participating && enabled && Boolean(activeAccount?.profileUrl)
-      ? await isBonusMilestoneCompleted(activeAccount?.profileUrl || "")
+    participating && enabled && profileUrl
+      ? await isBonusMilestoneCompleted(profileUrl)
       : false;
 
-  control.hidden = !enabled;
-  checkbox.disabled = !participating || !enabled;
-  checkbox.checked = completed;
-  control.classList.toggle("opacity-50", !participating);
-  control.classList.toggle("cursor-not-allowed", !participating || !enabled);
+  return {
+    completed,
+    enabled,
+    participating,
+    points,
+    profileUrl,
+  };
 }
 
-/** Install the popup-only self-confirmation control. */
-export function initializeBonusMilestoneControl(): void {
+/** Persist the checkbox value for the currently active profile. */
+export async function setActiveBonusMilestoneCompleted(
+  completed: boolean,
+): Promise<BonusMilestoneControlState> {
+  const activeAccount = await AccountService.getActiveAccount();
+  if (activeAccount?.profileUrl) {
+    await setBonusMilestoneCompleted(activeAccount.profileUrl, completed);
+  }
+  return getBonusMilestoneControlState();
+}
+
+/** Re-sync the popup control whenever account data or API results change. */
+export function watchBonusMilestoneControlState(
+  listener: () => void,
+): () => void {
+  return storage.watch<AccountsData>("local:accountsData", () => listener());
+}
+
+/**
+ * Mount the popup-only React control when this module is used from the popup.
+ * Rendering and lifecycle are intentionally kept out of this service module.
+ */
+function initializePopupControlMount(): void {
   if (typeof document === "undefined") return;
 
-  const install = () => {
+  const mount = () => {
     if (!document.getElementById("popup-content")) return;
-    void syncPopupControl();
-
-    const observer = new MutationObserver(() => {
-      void syncPopupControl();
-    });
-    observer.observe(document.body, { childList: true, subtree: true });
+    void import("../components/BonusMilestoneControl").then(
+      ({ mountBonusMilestoneControl }) => mountBonusMilestoneControl(),
+    );
   };
 
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", install, { once: true });
+    document.addEventListener("DOMContentLoaded", mount, { once: true });
   } else {
-    install();
+    mount();
   }
 }
 
-initializeBonusMilestoneControl();
+initializePopupControlMount();

--- a/services/bonusMilestoneService.ts
+++ b/services/bonusMilestoneService.ts
@@ -99,35 +99,3 @@ export function watchBonusMilestoneControlState(
 ): () => void {
   return storage.watch<AccountsData>("local:accountsData", listener);
 }
-
-/** Dynamically load and mount the React control only inside the popup document. */
-async function mountPopupControl(): Promise<void> {
-  if (!document.getElementById("popup-content")) return;
-
-  const { mountBonusMilestoneControl } =
-    await import("../components/BonusMilestoneControl");
-  mountBonusMilestoneControl();
-}
-
-/** Start the asynchronous popup mount without leaking a floating promise. */
-function startPopupControlMount(): void {
-  void mountPopupControl();
-}
-
-/**
- * Mount the popup-only React control when this module is used from the popup.
- * Rendering and state lifecycle stay inside the React component.
- */
-function initializePopupControlMount(): void {
-  if (typeof document === "undefined") return;
-
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", startPopupControlMount, {
-      once: true,
-    });
-  } else {
-    startPopupControlMount();
-  }
-}
-
-initializePopupControlMount();

--- a/services/bonusMilestoneService.ts
+++ b/services/bonusMilestoneService.ts
@@ -38,19 +38,24 @@ export async function setBonusMilestoneCompleted(
 /**
  * Resolve the score context for the account matching a requested profile URL.
  * This works for active-account refreshes and for updating a non-active account
- * from the options page.
+ * from the options page. Tests/background startup may not expose WXT storage yet,
+ * so unavailable account state safely falls back to no Facilitator bonus.
  */
 export async function getFacilitatorScoringContext(
   profileUrl: string,
 ): Promise<FacilitatorScoringContext> {
-  const canonical = canonicalizeProfileUrl(profileUrl) || profileUrl;
-  const account = await AccountService.isAccountExists(canonical);
-  const participating = Boolean(account?.facilitatorProgram);
-  const bonusMilestoneCompleted = participating
-    ? await isBonusMilestoneCompleted(canonical)
-    : false;
+  try {
+    const canonical = canonicalizeProfileUrl(profileUrl) || profileUrl;
+    const account = await AccountService.isAccountExists(canonical);
+    const participating = Boolean(account?.facilitatorProgram);
+    const bonusMilestoneCompleted = participating
+      ? await isBonusMilestoneCompleted(canonical)
+      : false;
 
-  return { participating, bonusMilestoneCompleted };
+    return { participating, bonusMilestoneCompleted };
+  } catch {
+    return { participating: false, bonusMilestoneCompleted: false };
+  }
 }
 
 async function syncPopupControl(): Promise<void> {

--- a/services/bonusMilestoneService.ts
+++ b/services/bonusMilestoneService.ts
@@ -13,6 +13,7 @@ export type BonusMilestoneControlState = {
   profileUrl: string;
 };
 
+/** Build a stable WXT storage key for one Skills Boost public profile. */
 function storageKey(profileUrl: string): `local:${string}` {
   const canonical = canonicalizeProfileUrl(profileUrl) || profileUrl.trim();
   const profileId = extractProfileId(canonical);
@@ -20,6 +21,7 @@ function storageKey(profileUrl: string): `local:${string}` {
   return `${STORAGE_PREFIX}:${identity}` as `local:${string}`;
 }
 
+/** Read whether a profile manually confirmed the Bonus Milestone. */
 export async function isBonusMilestoneCompleted(
   profileUrl: string,
 ): Promise<boolean> {
@@ -31,6 +33,7 @@ export async function isBonusMilestoneCompleted(
   }
 }
 
+/** Persist a profile's manual Bonus Milestone confirmation. */
 export async function setBonusMilestoneCompleted(
   profileUrl: string,
   completed: boolean,

--- a/services/facilitatorService.ts
+++ b/services/facilitatorService.ts
@@ -10,6 +10,9 @@ export type FacilitatorCounts = {
   faciTrivia?: number;
   faciSkill?: number;
   faciCompletion?: number;
+  bonusIncludedInTotal?: boolean;
+  appliedBonusPoints?: number;
+  baseTotalPoints?: number;
 };
 
 export type FacilitatorMilestoneRule = {
@@ -25,6 +28,11 @@ export type FacilitatorApiMetadata = {
   milestoneBonusPoints?: number;
   estimatedMilestone?: string | null;
   milestonePolicy?: string;
+  bonusMilestonePoints?: number | null;
+  bonusMilestoneCompleted?: boolean;
+  totalAppliedBonusPoints?: number;
+  adjustedArcadeTotalPoints?: number;
+  bonusIncludedInTotal?: boolean;
   milestones?: FacilitatorMilestoneRule[];
 };
 
@@ -158,7 +166,9 @@ export function getFacilitatorBonusFromApi(
   facilitator?: FacilitatorApiMetadata | null,
 ): number | null {
   const value =
-    facilitator?.milestoneBonusPoints ?? facilitator?.estimatedBonusPoints;
+    facilitator?.totalAppliedBonusPoints ??
+    facilitator?.milestoneBonusPoints ??
+    facilitator?.estimatedBonusPoints;
   const parsed = Number(value);
 
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
@@ -166,11 +176,21 @@ export function getFacilitatorBonusFromApi(
 
 /**
  * Return the bonus for the highest completed Facilitator milestone.
+ *
+ * New API v3 responses put the exact applied standard + Bonus Milestone amount
+ * into faciCounts.appliedBonusPoints. Prefer that value so every extension
+ * surface uses the backend result. Older cached responses fall back to the
+ * milestone rules below.
  */
 export function calculateFacilitatorBonus(
   faciCounts: FacilitatorCounts | null | undefined,
 ): number {
   if (!faciCounts) return 0;
+
+  const apiAppliedBonus = Number(faciCounts.appliedBonusPoints);
+  if (Number.isFinite(apiAppliedBonus) && apiAppliedBonus >= 0) {
+    return apiAppliedBonus;
+  }
 
   const current = normalizeCounts(faciCounts);
   let highestCompletedMilestone = 0;

--- a/services/facilitatorService.ts
+++ b/services/facilitatorService.ts
@@ -171,6 +171,7 @@ export function getFacilitatorBonusFromApi(
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
 }
 
+/** Read the separate Bonus Milestone amount already calculated by the API. */
 function getApiBonusMilestonePoints(
   faciCounts: FacilitatorCounts | null | undefined,
 ): number {

--- a/services/facilitatorService.ts
+++ b/services/facilitatorService.ts
@@ -10,9 +10,7 @@ export type FacilitatorCounts = {
   faciTrivia?: number;
   faciSkill?: number;
   faciCompletion?: number;
-  bonusIncludedInTotal?: boolean;
-  appliedBonusPoints?: number;
-  baseTotalPoints?: number;
+  manualBonusMilestonePoints?: number;
 };
 
 export type FacilitatorMilestoneRule = {
@@ -28,10 +26,9 @@ export type FacilitatorApiMetadata = {
   milestoneBonusPoints?: number;
   estimatedMilestone?: string | null;
   milestonePolicy?: string;
+  bonusMilestoneAvailablePoints?: number;
   bonusMilestonePoints?: number | null;
-  bonusMilestoneCompleted?: boolean;
-  totalAppliedBonusPoints?: number;
-  adjustedArcadeTotalPoints?: number;
+  bonusMilestoneStatus?: string;
   bonusIncludedInTotal?: boolean;
   milestones?: FacilitatorMilestoneRule[];
 };
@@ -158,39 +155,34 @@ export function syncFacilitatorRulesFromApi(
 }
 
 /**
- * Read the bonus directly from API metadata when available. This is useful for
- * callers that already have the complete Arcade response and should not
- * re-derive a value the backend has calculated.
+ * Read the standard milestone bonus directly from API metadata when available.
+ * The manually confirmed +10 Bonus Milestone remains client-owned and separate.
  */
 export function getFacilitatorBonusFromApi(
   facilitator?: FacilitatorApiMetadata | null,
 ): number | null {
   const value =
-    facilitator?.totalAppliedBonusPoints ??
-    facilitator?.milestoneBonusPoints ??
-    facilitator?.estimatedBonusPoints;
+    facilitator?.milestoneBonusPoints ?? facilitator?.estimatedBonusPoints;
   const parsed = Number(value);
 
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
 }
 
+function getManualBonusMilestonePoints(
+  faciCounts: FacilitatorCounts | null | undefined,
+): number {
+  const value = Number(faciCounts?.manualBonusMilestonePoints);
+  return Number.isFinite(value) && value >= 0 ? value : 0;
+}
+
 /**
- * Return the bonus for the highest completed Facilitator milestone.
- *
- * New API v3 responses put the exact applied standard + Bonus Milestone amount
- * into faciCounts.appliedBonusPoints. Prefer that value so every extension
- * surface uses the backend result. Older cached responses fall back to the
- * milestone rules below.
+ * Return the highest standard Facilitator milestone plus the separate manually
+ * confirmed Bonus Milestone amount already attached to the local response.
  */
 export function calculateFacilitatorBonus(
   faciCounts: FacilitatorCounts | null | undefined,
 ): number {
   if (!faciCounts) return 0;
-
-  const apiAppliedBonus = Number(faciCounts.appliedBonusPoints);
-  if (Number.isFinite(apiAppliedBonus) && apiAppliedBonus >= 0) {
-    return apiAppliedBonus;
-  }
 
   const current = normalizeCounts(faciCounts);
   let highestCompletedMilestone = 0;
@@ -209,11 +201,12 @@ export function calculateFacilitatorBonus(
     }
   }
 
-  return highestBonusPoints;
+  return highestBonusPoints + getManualBonusMilestonePoints(faciCounts);
 }
 
 /**
  * Return a per-milestone bonus breakdown while applying the highest-only rule.
+ * `manualBonus` is kept separate from the standard milestone map.
  */
 export function calculateMilestoneBonusBreakdown(
   faciCounts: FacilitatorCounts | null | undefined,
@@ -221,6 +214,7 @@ export function calculateMilestoneBonusBreakdown(
   if (!faciCounts) {
     return {
       milestones: { 1: 0, 2: 0, 3: 0, ultimate: 0 },
+      manualBonus: 0,
       total: 0,
       highestCompleted: 0,
     };
@@ -254,9 +248,12 @@ export function calculateMilestoneBonusBreakdown(
     }
   }
 
+  const manualBonus = getManualBonusMilestonePoints(faciCounts);
+
   return {
     milestones: milestoneBonus,
-    total: highestBonusPoints,
+    manualBonus,
+    total: highestBonusPoints + manualBonus,
     highestCompleted: highestCompletedMilestone,
   };
 }

--- a/services/facilitatorService.ts
+++ b/services/facilitatorService.ts
@@ -10,7 +10,7 @@ export type FacilitatorCounts = {
   faciTrivia?: number;
   faciSkill?: number;
   faciCompletion?: number;
-  manualBonusMilestonePoints?: number;
+  bonusMilestonePoints?: number;
 };
 
 export type FacilitatorMilestoneRule = {
@@ -26,7 +26,10 @@ export type FacilitatorApiMetadata = {
   milestoneBonusPoints?: number;
   estimatedMilestone?: string | null;
   milestonePolicy?: string;
+  bonusMilestoneEnabled?: boolean;
+  bonusMilestoneConfirmation?: string;
   bonusMilestoneAvailablePoints?: number;
+  bonusMilestoneCompleted?: boolean;
   bonusMilestonePoints?: number | null;
   bonusMilestoneStatus?: string;
   bonusIncludedInTotal?: boolean;
@@ -156,7 +159,7 @@ export function syncFacilitatorRulesFromApi(
 
 /**
  * Read the standard milestone bonus directly from API metadata when available.
- * The manually confirmed +10 Bonus Milestone remains client-owned and separate.
+ * Bonus Milestone points are applied separately from facilitator metadata.
  */
 export function getFacilitatorBonusFromApi(
   facilitator?: FacilitatorApiMetadata | null,
@@ -168,16 +171,16 @@ export function getFacilitatorBonusFromApi(
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
 }
 
-function getManualBonusMilestonePoints(
+function getApiBonusMilestonePoints(
   faciCounts: FacilitatorCounts | null | undefined,
 ): number {
-  const value = Number(faciCounts?.manualBonusMilestonePoints);
+  const value = Number(faciCounts?.bonusMilestonePoints);
   return Number.isFinite(value) && value >= 0 ? value : 0;
 }
 
 /**
- * Return the highest standard Facilitator milestone plus the separate manually
- * confirmed Bonus Milestone amount already attached to the local response.
+ * Return the highest standard Facilitator milestone plus the separate Bonus
+ * Milestone amount already calculated by the API for the self-reported flag.
  */
 export function calculateFacilitatorBonus(
   faciCounts: FacilitatorCounts | null | undefined,
@@ -201,12 +204,12 @@ export function calculateFacilitatorBonus(
     }
   }
 
-  return highestBonusPoints + getManualBonusMilestonePoints(faciCounts);
+  return highestBonusPoints + getApiBonusMilestonePoints(faciCounts);
 }
 
 /**
  * Return a per-milestone bonus breakdown while applying the highest-only rule.
- * `manualBonus` is kept separate from the standard milestone map.
+ * `bonusMilestone` remains separate from the standard milestone map.
  */
 export function calculateMilestoneBonusBreakdown(
   faciCounts: FacilitatorCounts | null | undefined,
@@ -214,7 +217,7 @@ export function calculateMilestoneBonusBreakdown(
   if (!faciCounts) {
     return {
       milestones: { 1: 0, 2: 0, 3: 0, ultimate: 0 },
-      manualBonus: 0,
+      bonusMilestone: 0,
       total: 0,
       highestCompleted: 0,
     };
@@ -248,12 +251,12 @@ export function calculateMilestoneBonusBreakdown(
     }
   }
 
-  const manualBonus = getManualBonusMilestonePoints(faciCounts);
+  const bonusMilestone = getApiBonusMilestonePoints(faciCounts);
 
   return {
     milestones: milestoneBonus,
-    manualBonus,
-    total: highestBonusPoints + manualBonus,
+    bonusMilestone,
+    total: highestBonusPoints + bonusMilestone,
     highestCompleted: highestCompletedMilestone,
   };
 }

--- a/tests/services/facilitatorService.test.ts
+++ b/tests/services/facilitatorService.test.ts
@@ -55,6 +55,17 @@ describe("calculateFacilitatorBonus", () => {
     expect(calculateFacilitatorBonus(null)).toBe(0);
   });
 
+  it("returns the exact API-applied standard + Bonus Milestone amount when present", () => {
+    expect(
+      calculateFacilitatorBonus({
+        faciGame: 6,
+        faciSkill: 18,
+        appliedBonusPoints: 15,
+        baseTotalPoints: 15,
+      }),
+    ).toBe(15);
+  });
+
   it("returns 0 when no milestone is completed", () => {
     expect(
       calculateFacilitatorBonus({
@@ -182,6 +193,13 @@ describe("API-provided Facilitator rules", () => {
       getFacilitatorBonusFromApi({
         estimatedBonusPoints: 5,
         milestoneBonusPoints: 15,
+      }),
+    ).toBe(15);
+    expect(
+      getFacilitatorBonusFromApi({
+        estimatedBonusPoints: 5,
+        milestoneBonusPoints: 5,
+        totalAppliedBonusPoints: 15,
       }),
     ).toBe(15);
     expect(getFacilitatorBonusFromApi()).toBeNull();

--- a/tests/services/facilitatorService.test.ts
+++ b/tests/services/facilitatorService.test.ts
@@ -55,13 +55,12 @@ describe("calculateFacilitatorBonus", () => {
     expect(calculateFacilitatorBonus(null)).toBe(0);
   });
 
-  it("returns the exact API-applied standard + Bonus Milestone amount when present", () => {
+  it("adds the manually confirmed Bonus Milestone separately", () => {
     expect(
       calculateFacilitatorBonus({
         faciGame: 6,
         faciSkill: 18,
-        appliedBonusPoints: 15,
-        baseTotalPoints: 15,
+        manualBonusMilestonePoints: 10,
       }),
     ).toBe(15);
   });
@@ -152,6 +151,7 @@ describe("calculateMilestoneBonusBreakdown", () => {
   it("returns zero breakdown for null/undefined", () => {
     const result = calculateMilestoneBonusBreakdown(null);
     expect(result.total).toBe(0);
+    expect(result.manualBonus).toBe(0);
     expect(result.highestCompleted).toBe(0);
     expect(result.milestones["1"]).toBe(0);
   });
@@ -166,10 +166,26 @@ describe("calculateMilestoneBonusBreakdown", () => {
 
     expect(result.highestCompleted).toBe(1);
     expect(result.total).toBe(5);
+    expect(result.manualBonus).toBe(0);
     expect(result.milestones["1"]).toBe(5);
     expect(result.milestones["2"]).toBe(0);
     expect(result.milestones["3"]).toBe(0);
     expect(result.milestones.ultimate).toBe(0);
+  });
+
+  it("keeps the manual +10 outside the standard milestone map", () => {
+    const result = calculateMilestoneBonusBreakdown({
+      faciGame: 6,
+      faciTrivia: 0,
+      faciSkill: 18,
+      faciCompletion: 0,
+      manualBonusMilestonePoints: 10,
+    });
+
+    expect(result.highestCompleted).toBe(1);
+    expect(result.milestones["1"]).toBe(5);
+    expect(result.manualBonus).toBe(10);
+    expect(result.total).toBe(15);
   });
 
   it("returns correct breakdown for ultimate milestone", () => {
@@ -187,19 +203,13 @@ describe("calculateMilestoneBonusBreakdown", () => {
 });
 
 describe("API-provided Facilitator rules", () => {
-  it("reads the backend-calculated bonus directly when present", () => {
+  it("reads only the standard milestone bonus from API metadata", () => {
     expect(getFacilitatorBonusFromApi({ estimatedBonusPoints: 5 })).toBe(5);
     expect(
       getFacilitatorBonusFromApi({
         estimatedBonusPoints: 5,
         milestoneBonusPoints: 15,
-      }),
-    ).toBe(15);
-    expect(
-      getFacilitatorBonusFromApi({
-        estimatedBonusPoints: 5,
-        milestoneBonusPoints: 5,
-        totalAppliedBonusPoints: 15,
+        bonusMilestoneAvailablePoints: 10,
       }),
     ).toBe(15);
     expect(getFacilitatorBonusFromApi()).toBeNull();

--- a/tests/services/facilitatorService.test.ts
+++ b/tests/services/facilitatorService.test.ts
@@ -55,14 +55,24 @@ describe("calculateFacilitatorBonus", () => {
     expect(calculateFacilitatorBonus(null)).toBe(0);
   });
 
-  it("adds the manually confirmed Bonus Milestone separately", () => {
+  it("adds the API-calculated Bonus Milestone separately", () => {
     expect(
       calculateFacilitatorBonus({
         faciGame: 6,
         faciSkill: 18,
-        manualBonusMilestonePoints: 10,
+        bonusMilestonePoints: 10,
       }),
     ).toBe(15);
+  });
+
+  it("uses whatever Bonus Milestone amount the API returns", () => {
+    expect(
+      calculateFacilitatorBonus({
+        faciGame: 6,
+        faciSkill: 18,
+        bonusMilestonePoints: 20,
+      }),
+    ).toBe(25);
   });
 
   it("returns 0 when no milestone is completed", () => {
@@ -151,7 +161,7 @@ describe("calculateMilestoneBonusBreakdown", () => {
   it("returns zero breakdown for null/undefined", () => {
     const result = calculateMilestoneBonusBreakdown(null);
     expect(result.total).toBe(0);
-    expect(result.manualBonus).toBe(0);
+    expect(result.bonusMilestone).toBe(0);
     expect(result.highestCompleted).toBe(0);
     expect(result.milestones["1"]).toBe(0);
   });
@@ -166,25 +176,25 @@ describe("calculateMilestoneBonusBreakdown", () => {
 
     expect(result.highestCompleted).toBe(1);
     expect(result.total).toBe(5);
-    expect(result.manualBonus).toBe(0);
+    expect(result.bonusMilestone).toBe(0);
     expect(result.milestones["1"]).toBe(5);
     expect(result.milestones["2"]).toBe(0);
     expect(result.milestones["3"]).toBe(0);
     expect(result.milestones.ultimate).toBe(0);
   });
 
-  it("keeps the manual +10 outside the standard milestone map", () => {
+  it("keeps the API Bonus Milestone outside the standard milestone map", () => {
     const result = calculateMilestoneBonusBreakdown({
       faciGame: 6,
       faciTrivia: 0,
       faciSkill: 18,
       faciCompletion: 0,
-      manualBonusMilestonePoints: 10,
+      bonusMilestonePoints: 10,
     });
 
     expect(result.highestCompleted).toBe(1);
     expect(result.milestones["1"]).toBe(5);
-    expect(result.manualBonus).toBe(10);
+    expect(result.bonusMilestone).toBe(10);
     expect(result.total).toBe(15);
   });
 
@@ -210,6 +220,7 @@ describe("API-provided Facilitator rules", () => {
         estimatedBonusPoints: 5,
         milestoneBonusPoints: 15,
         bonusMilestoneAvailablePoints: 10,
+        bonusMilestonePoints: 10,
       }),
     ).toBe(15);
     expect(getFacilitatorBonusFromApi()).toBeNull();

--- a/tests/utils/arcadeRequestSignature.test.ts
+++ b/tests/utils/arcadeRequestSignature.test.ts
@@ -86,6 +86,23 @@ describe("buildArcadeSignatureHeaders", () => {
     );
   });
 
+  it("sends true when the user has manually confirmed Bonus Milestone", async () => {
+    vi.stubGlobal("storage", {
+      getItem: vi.fn().mockResolvedValue(true),
+      setItem: vi.fn().mockResolvedValue(undefined),
+    });
+    const payload: Record<string, unknown> = {
+      url: "https://www.skills.google/public_profiles/abc123",
+    };
+
+    await buildArcadeSignatureHeaders(
+      "https://private-api.example.test/api/v3/arcade",
+      payload,
+    );
+
+    expect(payload.facilitator).toEqual({ bonusMilestoneCompleted: true });
+  });
+
   it("produces the same signature with or without a trailing endpoint slash", async () => {
     vi.spyOn(Date, "now").mockReturnValue(1_786_420_000_000);
     vi.spyOn(crypto, "randomUUID").mockReturnValue(

--- a/tests/utils/arcadeRequestSignature.test.ts
+++ b/tests/utils/arcadeRequestSignature.test.ts
@@ -34,6 +34,7 @@ describe("buildArcadeSignatureHeaders", () => {
       ),
     ).resolves.toEqual({});
     expect(payload.extensionVersion).toBe("1.3.1");
+    expect(payload.facilitator).toEqual({ bonusMilestoneCompleted: false });
   });
 
   it("does not block Arcade v3 when only one signing credential is present", async () => {
@@ -60,7 +61,7 @@ describe("buildArcadeSignatureHeaders", () => {
     ).rejects.toThrow(/requires the \/api\/v3\/arcade endpoint/i);
   });
 
-  it("signs the manifest version in the body and exposes it as a header", async () => {
+  it("signs only the Bonus Milestone self-report flag with the manifest version", async () => {
     const payload: Record<string, unknown> = {
       url: "https://www.skills.google/public_profiles/abc123",
       profileId: "abc123",
@@ -72,6 +73,8 @@ describe("buildArcadeSignatureHeaders", () => {
     );
 
     expect(payload.extensionVersion).toBe("1.3.1");
+    expect(payload.facilitator).toEqual({ bonusMilestoneCompleted: false });
+    expect(payload.facilitator).not.toHaveProperty("participating");
     expect(headers).toEqual(
       expect.objectContaining({
         "X-Arcade-Key": "release-client-key",

--- a/tests/utils/arcadeRequestSignature.test.ts
+++ b/tests/utils/arcadeRequestSignature.test.ts
@@ -1,9 +1,19 @@
 import { webcrypto } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { isBonusMilestoneCompletedMock } = vi.hoisted(() => ({
+  isBonusMilestoneCompletedMock: vi.fn(),
+}));
+
+vi.mock("../../services/bonusMilestoneService", () => ({
+  isBonusMilestoneCompleted: isBonusMilestoneCompletedMock,
+}));
+
 import { buildArcadeSignatureHeaders } from "../../utils/arcadeRequestSignature";
 
 describe("buildArcadeSignatureHeaders", () => {
   beforeEach(() => {
+    isBonusMilestoneCompletedMock.mockResolvedValue(false);
     vi.stubGlobal("crypto", webcrypto as unknown as Crypto);
     vi.stubGlobal("browser", {
       runtime: {
@@ -87,10 +97,7 @@ describe("buildArcadeSignatureHeaders", () => {
   });
 
   it("sends true when the user has manually confirmed Bonus Milestone", async () => {
-    vi.stubGlobal("storage", {
-      getItem: vi.fn().mockResolvedValue(true),
-      setItem: vi.fn().mockResolvedValue(undefined),
-    });
+    isBonusMilestoneCompletedMock.mockResolvedValue(true);
     const payload: Record<string, unknown> = {
       url: "https://www.skills.google/public_profiles/abc123",
     };

--- a/types/popup.ts
+++ b/types/popup.ts
@@ -33,7 +33,6 @@ export interface FacilitatorApiMetadata {
   estimatedMilestone?: string | null;
   estimatedBonusPoints?: number;
   milestoneBonusPoints?: number;
-  appliedMilestoneBonusPoints?: number;
   bonusIncludedInTotal?: boolean;
   gamePoints?: number;
   skillPoints?: number;
@@ -41,13 +40,9 @@ export interface FacilitatorApiMetadata {
   baseArcadePoints?: number;
   pointsAlreadyIncludedInArcadeTotal?: number;
   estimatedFacilitatorPoints?: number;
-  participating?: boolean;
-  bonusMilestoneCompleted?: boolean;
   bonusMilestoneAvailablePoints?: number;
   bonusMilestonePoints?: number | null;
   bonusMilestoneStatus?: string;
-  totalAppliedBonusPoints?: number;
-  adjustedArcadeTotalPoints?: number;
   milestonePolicy?: string;
   milestones?: FacilitatorMilestoneRule[];
 }
@@ -58,11 +53,6 @@ export interface ArcadeData {
   userDetails?: UserDetail | UserDetail[]; // Support both single object and array
   arcadePoints?: {
     totalPoints?: number;
-    baseTotalPoints?: number;
-    adjustedTotalPoints?: number;
-    facilitatorBonusPoints?: number;
-    milestoneBonusPoints?: number;
-    bonusMilestonePoints?: number;
     gamePoints?: number;
     triviaPoints?: number;
     skillPoints?: number;
@@ -76,9 +66,7 @@ export interface ArcadeData {
     faciCompletion?: number;
     completedFaciCount?: number;
     completedFaciSkillCount?: number;
-    bonusIncludedInTotal?: boolean;
-    appliedBonusPoints?: number;
-    baseTotalPoints?: number;
+    manualBonusMilestonePoints?: number;
   };
   // Canonical Arcade v2/v3 Facilitator contract.
   facilitator?: FacilitatorApiMetadata;

--- a/types/popup.ts
+++ b/types/popup.ts
@@ -33,6 +33,7 @@ export interface FacilitatorApiMetadata {
   estimatedMilestone?: string | null;
   estimatedBonusPoints?: number;
   milestoneBonusPoints?: number;
+  appliedMilestoneBonusPoints?: number;
   bonusIncludedInTotal?: boolean;
   gamePoints?: number;
   skillPoints?: number;
@@ -40,8 +41,13 @@ export interface FacilitatorApiMetadata {
   baseArcadePoints?: number;
   pointsAlreadyIncludedInArcadeTotal?: number;
   estimatedFacilitatorPoints?: number;
+  participating?: boolean;
+  bonusMilestoneCompleted?: boolean;
+  bonusMilestoneAvailablePoints?: number;
   bonusMilestonePoints?: number | null;
   bonusMilestoneStatus?: string;
+  totalAppliedBonusPoints?: number;
+  adjustedArcadeTotalPoints?: number;
   milestonePolicy?: string;
   milestones?: FacilitatorMilestoneRule[];
 }
@@ -52,6 +58,11 @@ export interface ArcadeData {
   userDetails?: UserDetail | UserDetail[]; // Support both single object and array
   arcadePoints?: {
     totalPoints?: number;
+    baseTotalPoints?: number;
+    adjustedTotalPoints?: number;
+    facilitatorBonusPoints?: number;
+    milestoneBonusPoints?: number;
+    bonusMilestonePoints?: number;
     gamePoints?: number;
     triviaPoints?: number;
     skillPoints?: number;
@@ -65,8 +76,11 @@ export interface ArcadeData {
     faciCompletion?: number;
     completedFaciCount?: number;
     completedFaciSkillCount?: number;
+    bonusIncludedInTotal?: boolean;
+    appliedBonusPoints?: number;
+    baseTotalPoints?: number;
   };
-  // Canonical Arcade v2 Facilitator contract.
+  // Canonical Arcade v2/v3 Facilitator contract.
   facilitator?: FacilitatorApiMetadata;
   // Deprecated legacy shape retained only so previously stored responses can
   // still be read safely. Current network requests do not consume this field.

--- a/types/popup.ts
+++ b/types/popup.ts
@@ -40,7 +40,10 @@ export interface FacilitatorApiMetadata {
   baseArcadePoints?: number;
   pointsAlreadyIncludedInArcadeTotal?: number;
   estimatedFacilitatorPoints?: number;
+  bonusMilestoneEnabled?: boolean;
+  bonusMilestoneConfirmation?: string;
   bonusMilestoneAvailablePoints?: number;
+  bonusMilestoneCompleted?: boolean;
   bonusMilestonePoints?: number | null;
   bonusMilestoneStatus?: string;
   milestonePolicy?: string;
@@ -66,7 +69,7 @@ export interface ArcadeData {
     faciCompletion?: number;
     completedFaciCount?: number;
     completedFaciSkillCount?: number;
-    manualBonusMilestonePoints?: number;
+    bonusMilestonePoints?: number;
   };
   // Canonical Arcade v2/v3 Facilitator contract.
   facilitator?: FacilitatorApiMetadata;

--- a/utils/arcadeRequestSignature.ts
+++ b/utils/arcadeRequestSignature.ts
@@ -1,3 +1,5 @@
+import { getFacilitatorScoringContext } from "../services/bonusMilestoneService";
+
 const encoder = new TextEncoder();
 
 /** Convert an ArrayBuffer into a lowercase hexadecimal string. */
@@ -85,9 +87,10 @@ function getCanonicalPathname(endpoint: string): string {
 }
 
 /**
- * Add the extension version to the Arcade v3 body and sign the request when
- * both client credentials are available. During rollout, missing credentials
- * intentionally produce an unsigned v3 request instead of blocking the fetch.
+ * Add the extension version and the account's Facilitator scoring state to the
+ * Arcade v3 body before signing. Mutating the shared body object is intentional:
+ * ArcadeApiService sends that exact object after this function returns, keeping
+ * the signed body and transmitted body byte-for-byte equivalent.
  */
 export async function buildArcadeSignatureHeaders(
   endpoint: string,
@@ -99,7 +102,12 @@ export async function buildArcadeSignatureHeaders(
 
   const extensionVersion = getExtensionVersion();
   if (body && typeof body === "object" && !Array.isArray(body)) {
-    (body as Record<string, unknown>).extensionVersion = extensionVersion;
+    const record = body as Record<string, unknown>;
+    const profileUrl = typeof record.url === "string" ? record.url : "";
+    if (profileUrl) {
+      record.facilitator = await getFacilitatorScoringContext(profileUrl);
+    }
+    record.extensionVersion = extensionVersion;
   }
 
   const clientKey = String(import.meta.env.WXT_ARCADE_CLIENT_KEY || "").trim();

--- a/utils/arcadeRequestSignature.ts
+++ b/utils/arcadeRequestSignature.ts
@@ -1,3 +1,5 @@
+import "../services/bonusMilestoneService";
+
 const encoder = new TextEncoder();
 
 /** Convert an ArrayBuffer into a lowercase hexadecimal string. */

--- a/utils/arcadeRequestSignature.ts
+++ b/utils/arcadeRequestSignature.ts
@@ -1,4 +1,4 @@
-import "../services/bonusMilestoneService";
+import { isBonusMilestoneCompleted } from "../services/bonusMilestoneService";
 
 const encoder = new TextEncoder();
 
@@ -87,9 +87,9 @@ function getCanonicalPathname(endpoint: string): string {
 }
 
 /**
- * Add the extension version to the Arcade v3 body and sign the request when
- * both client credentials are available. During rollout, missing credentials
- * intentionally produce an unsigned v3 request instead of blocking the fetch.
+ * Add the extension version and self-reported Bonus Milestone completion flag
+ * before signing. The API owns season availability and point values; the client
+ * sends only whether the user manually confirmed completion.
  */
 export async function buildArcadeSignatureHeaders(
   endpoint: string,
@@ -101,7 +101,14 @@ export async function buildArcadeSignatureHeaders(
 
   const extensionVersion = getExtensionVersion();
   if (body && typeof body === "object" && !Array.isArray(body)) {
-    (body as Record<string, unknown>).extensionVersion = extensionVersion;
+    const record = body as Record<string, unknown>;
+    const profileUrl = typeof record.url === "string" ? record.url : "";
+    if (profileUrl) {
+      record.facilitator = {
+        bonusMilestoneCompleted: await isBonusMilestoneCompleted(profileUrl),
+      };
+    }
+    record.extensionVersion = extensionVersion;
   }
 
   const clientKey = String(import.meta.env.WXT_ARCADE_CLIENT_KEY || "").trim();

--- a/utils/arcadeRequestSignature.ts
+++ b/utils/arcadeRequestSignature.ts
@@ -1,5 +1,3 @@
-import { getFacilitatorScoringContext } from "../services/bonusMilestoneService";
-
 const encoder = new TextEncoder();
 
 /** Convert an ArrayBuffer into a lowercase hexadecimal string. */
@@ -87,10 +85,9 @@ function getCanonicalPathname(endpoint: string): string {
 }
 
 /**
- * Add the extension version and the account's Facilitator scoring state to the
- * Arcade v3 body before signing. Mutating the shared body object is intentional:
- * ArcadeApiService sends that exact object after this function returns, keeping
- * the signed body and transmitted body byte-for-byte equivalent.
+ * Add the extension version to the Arcade v3 body and sign the request when
+ * both client credentials are available. During rollout, missing credentials
+ * intentionally produce an unsigned v3 request instead of blocking the fetch.
  */
 export async function buildArcadeSignatureHeaders(
   endpoint: string,
@@ -102,12 +99,7 @@ export async function buildArcadeSignatureHeaders(
 
   const extensionVersion = getExtensionVersion();
   if (body && typeof body === "object" && !Array.isArray(body)) {
-    const record = body as Record<string, unknown>;
-    const profileUrl = typeof record.url === "string" ? record.url : "";
-    if (profileUrl) {
-      record.facilitator = await getFacilitatorScoringContext(profileUrl);
-    }
-    record.extensionVersion = extensionVersion;
+    (body as Record<string, unknown>).extensionVersion = extensionVersion;
   }
 
   const clientKey = String(import.meta.env.WXT_ARCADE_CLIENT_KEY || "").trim();

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -3,6 +3,7 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react-swc";
 import type { Plugin } from "vite";
 
+/** Inject popup-only bootstrap scripts and compact-mode CSS before app startup. */
 function popupSizeBootstrapPlugin(): Plugin {
   return {
     name: "eplus-popup-size-bootstrap",
@@ -44,6 +45,14 @@ function popupSizeBootstrapPlugin(): Plugin {
               attrs: {
                 type: "module",
                 src: "/entrypoints/popup/compactModeSync.ts",
+              },
+            },
+            {
+              tag: "script",
+              injectTo: "head",
+              attrs: {
+                type: "module",
+                src: "/entrypoints/popup/bonusMilestoneControl.tsx",
               },
             },
           ],


### PR DESCRIPTION
Superseded by #218, which recreates the Bonus Milestone changes cleanly on top of `dev` and has been merged.

Original implementation notes:
- Persist Bonus Milestone completion locally per Google Skills profile.
- Add only `facilitator.bonusMilestoneCompleted` to the signed Arcade v3 body before HMAC.
- API owns season availability and point values.
- Standard Facilitator milestone logic remains separate.