### PR TITLE
Add API-backed Bonus Milestone control to dev

### DIFF
--- a/components/BonusMilestoneControl.tsx
+++ b/components/BonusMilestoneControl.tsx
@@ -1,0 +1,145 @@
+import { useCallback, useEffect, useState, type ChangeEvent } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { browser } from "wxt/browser";
+import {
+  getBonusMilestoneControlState,
+  setActiveBonusMilestoneCompleted,
+  watchBonusMilestoneControlState,
+  type BonusMilestoneControlState,
+} from "../services/bonusMilestoneService";
+
+const ROOT_ID = "facilitator-bonus-milestone-root";
+
+const EMPTY_STATE: BonusMilestoneControlState = {
+  completed: false,
+  enabled: true,
+  participating: false,
+  points: 10,
+  profileUrl: "",
+};
+
+/** Return a localized message while preserving a safe English fallback. */
+function getMessage(key: string, fallback: string): string {
+  try {
+    return (
+      browser.i18n.getMessage(
+        key as Parameters<typeof browser.i18n.getMessage>[0],
+      ) || fallback
+    );
+  } catch {
+    return fallback;
+  }
+}
+
+/** Render the profile-scoped Bonus Milestone self-confirmation control. */
+function BonusMilestoneControl() {
+  const [state, setState] = useState<BonusMilestoneControlState>(EMPTY_STATE);
+  const [saving, setSaving] = useState(false);
+
+  const reload = useCallback(
+    /** Reload the control state from the active profile and API snapshot. */
+    async function reloadControlState() {
+      setState(await getBonusMilestoneControlState());
+    },
+    [],
+  );
+
+  useEffect(
+    /** Load the initial state and subscribe to active-account changes. */
+    function subscribeToBonusMilestoneState() {
+      void reload();
+      return watchBonusMilestoneControlState(
+        function reloadAfterAccountChange() {
+          void reload();
+        },
+      );
+    },
+    [reload],
+  );
+
+  const handleChange = useCallback(
+    /** Persist one checkbox change and then refresh the signed Arcade request. */
+    async function persistBonusMilestoneChange(completed: boolean) {
+      setSaving(true);
+
+      try {
+        setState(await setActiveBonusMilestoneCompleted(completed));
+
+        // Reuse the existing refresh flow so the signed v3 request sends the
+        // self-report and the API returns the season-owned applied bonus points.
+        document.querySelector<HTMLButtonElement>(".refresh-button")?.click();
+      } finally {
+        setSaving(false);
+      }
+    },
+    [],
+  );
+
+  const handleCheckboxChange = useCallback(
+    /** Forward the checkbox state to the async persistence handler. */
+    function handleCheckboxEvent(event: ChangeEvent<HTMLInputElement>) {
+      void handleChange(event.currentTarget.checked);
+    },
+    [handleChange],
+  );
+
+  if (!state.enabled) return null;
+
+  const title = getMessage("facilitatorBonus", "Facilitator Bonus").replace(
+    /[:：]\s*$/u,
+    "",
+  );
+  const pointsWord = getMessage("textPoints", "points");
+  const reward = `+${state.points.toString()} ${pointsWord}`;
+  const disabled = !state.participating || saving;
+
+  return (
+    <label
+      className={`flex items-center justify-between gap-3 bg-emerald-500/10 backdrop-blur-md rounded-lg p-3 mb-3 border border-emerald-400/30 ${
+        disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"
+      }`}
+    >
+      <span className="flex items-center min-w-0">
+        <i className="fa-solid fa-circle-check text-emerald-400 text-lg mr-2" />
+        <span className="min-w-0">
+          <strong className="block text-white text-sm">{title}</strong>
+          <small className="block text-emerald-300/70 text-xs">{reward}</small>
+        </span>
+      </span>
+      <input
+        type="checkbox"
+        className="h-5 w-5 accent-emerald-500"
+        aria-label={`${title}: ${reward}`}
+        checked={state.completed}
+        disabled={disabled}
+        onChange={handleCheckboxChange}
+      />
+    </label>
+  );
+}
+
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+
+/** Mount exactly one React root into the existing popup milestone section. */
+export function mountBonusMilestoneControl(): void {
+  const section = document.getElementById("milestones-section");
+  if (!section) return;
+
+  if (!host?.isConnected) {
+    const existing = document.getElementById(ROOT_ID);
+    if (existing) existing.remove();
+
+    host = document.createElement("div");
+    host.id = ROOT_ID;
+
+    const milestoneGrid =
+      section.querySelector(".milestone-card")?.parentElement;
+    if (milestoneGrid) milestoneGrid.before(host);
+    else section.appendChild(host);
+
+    root = createRoot(host);
+  }
+
+  root?.render(<BonusMilestoneControl />);
+}

--- a/entrypoints/popup/bonusMilestoneControl.tsx
+++ b/entrypoints/popup/bonusMilestoneControl.tsx
@@ -1,0 +1,15 @@
+import { mountBonusMilestoneControl } from "../../components/BonusMilestoneControl";
+
+/** Mount the Bonus Milestone React control after the popup DOM is available. */
+function initializeBonusMilestoneControl(): void {
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", mountBonusMilestoneControl, {
+      once: true,
+    });
+    return;
+  }
+
+  mountBonusMilestoneControl();
+}
+
+initializeBonusMilestoneControl();

--- a/services/bonusMilestoneService.ts
+++ b/services/bonusMilestoneService.ts
@@ -1,0 +1,101 @@
+import { storage } from "wxt/utils/storage";
+import type { AccountsData, ArcadeData } from "../types";
+import { canonicalizeProfileUrl, extractProfileId } from "../utils/profileUrl";
+import AccountService from "./accountService";
+
+const STORAGE_PREFIX = "local:facilitatorBonusMilestone";
+export const DEFAULT_BONUS_MILESTONE_POINTS = 10;
+
+export type BonusMilestoneControlState = {
+  completed: boolean;
+  enabled: boolean;
+  participating: boolean;
+  points: number;
+  profileUrl: string;
+};
+
+/** Build a stable WXT storage key for one Skills Boost public profile. */
+function storageKey(profileUrl: string): `local:${string}` {
+  const canonical = canonicalizeProfileUrl(profileUrl) || profileUrl.trim();
+  const profileId = extractProfileId(canonical);
+  const identity = profileId || encodeURIComponent(canonical.toLowerCase());
+  return `${STORAGE_PREFIX}:${identity}` as `local:${string}`;
+}
+
+/** Read whether a profile manually confirmed the Bonus Milestone. */
+export async function isBonusMilestoneCompleted(
+  profileUrl: string,
+): Promise<boolean> {
+  if (!profileUrl) return false;
+  try {
+    return Boolean(await storage.getItem<boolean>(storageKey(profileUrl)));
+  } catch {
+    return false;
+  }
+}
+
+/** Persist a profile's manual Bonus Milestone confirmation. */
+export async function setBonusMilestoneCompleted(
+  profileUrl: string,
+  completed: boolean,
+): Promise<void> {
+  if (!profileUrl) return;
+  await storage.setItem(storageKey(profileUrl), Boolean(completed));
+}
+
+/** Read the API-owned Bonus Milestone amount, with +10 only for old responses. */
+export function getBonusMilestoneAvailablePoints(
+  arcadeData?: ArcadeData | null,
+): number {
+  const value = Number(arcadeData?.facilitator?.bonusMilestoneAvailablePoints);
+  return Number.isFinite(value) && value >= 0
+    ? value
+    : DEFAULT_BONUS_MILESTONE_POINTS;
+}
+
+/** Old API responses did not expose availability, so keep the current control visible. */
+export function isBonusMilestoneEnabled(
+  arcadeData?: ArcadeData | null,
+): boolean {
+  const value = arcadeData?.facilitator?.bonusMilestoneEnabled;
+  return typeof value === "boolean" ? value : true;
+}
+
+/** Resolve all state required by the popup control without rendering any UI. */
+export async function getBonusMilestoneControlState(): Promise<BonusMilestoneControlState> {
+  const activeAccount = await AccountService.getActiveAccount();
+  const profileUrl = activeAccount?.profileUrl || "";
+  const enabled = isBonusMilestoneEnabled(activeAccount?.arcadeData);
+  const participating = Boolean(activeAccount?.facilitatorProgram);
+  const points = getBonusMilestoneAvailablePoints(activeAccount?.arcadeData);
+  const completed =
+    participating && enabled && profileUrl
+      ? await isBonusMilestoneCompleted(profileUrl)
+      : false;
+
+  return {
+    completed,
+    enabled,
+    participating,
+    points,
+    profileUrl,
+  };
+}
+
+/** Persist the checkbox value for the currently active profile. */
+export async function setActiveBonusMilestoneCompleted(
+  completed: boolean,
+): Promise<BonusMilestoneControlState> {
+  const activeAccount = await AccountService.getActiveAccount();
+  if (activeAccount?.profileUrl) {
+    await setBonusMilestoneCompleted(activeAccount.profileUrl, completed);
+  }
+  return getBonusMilestoneControlState();
+}
+
+/** Re-sync the popup control whenever account data or API results change. */
+export function watchBonusMilestoneControlState(
+  listener: () => void,
+): () => void {
+  return storage.watch<AccountsData>("local:accountsData", listener);
+}

--- a/services/facilitatorService.ts
+++ b/services/facilitatorService.ts
@@ -10,6 +10,7 @@ export type FacilitatorCounts = {
   faciTrivia?: number;
   faciSkill?: number;
   faciCompletion?: number;
+  bonusMilestonePoints?: number;
 };
 
 export type FacilitatorMilestoneRule = {
@@ -25,6 +26,13 @@ export type FacilitatorApiMetadata = {
   milestoneBonusPoints?: number;
   estimatedMilestone?: string | null;
   milestonePolicy?: string;
+  bonusMilestoneEnabled?: boolean;
+  bonusMilestoneConfirmation?: string;
+  bonusMilestoneAvailablePoints?: number;
+  bonusMilestoneCompleted?: boolean;
+  bonusMilestonePoints?: number | null;
+  bonusMilestoneStatus?: string;
+  bonusIncludedInTotal?: boolean;
   milestones?: FacilitatorMilestoneRule[];
 };
 
@@ -150,9 +158,8 @@ export function syncFacilitatorRulesFromApi(
 }
 
 /**
- * Read the bonus directly from API metadata when available. This is useful for
- * callers that already have the complete Arcade response and should not
- * re-derive a value the backend has calculated.
+ * Read the standard milestone bonus directly from API metadata when available.
+ * Bonus Milestone points are applied separately from facilitator metadata.
  */
 export function getFacilitatorBonusFromApi(
   facilitator?: FacilitatorApiMetadata | null,
@@ -164,8 +171,17 @@ export function getFacilitatorBonusFromApi(
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
 }
 
+/** Read the separate Bonus Milestone amount already calculated by the API. */
+function getApiBonusMilestonePoints(
+  faciCounts: FacilitatorCounts | null | undefined,
+): number {
+  const value = Number(faciCounts?.bonusMilestonePoints);
+  return Number.isFinite(value) && value >= 0 ? value : 0;
+}
+
 /**
- * Return the bonus for the highest completed Facilitator milestone.
+ * Return the highest standard Facilitator milestone plus the separate Bonus
+ * Milestone amount already calculated by the API for the self-reported flag.
  */
 export function calculateFacilitatorBonus(
   faciCounts: FacilitatorCounts | null | undefined,
@@ -189,11 +205,12 @@ export function calculateFacilitatorBonus(
     }
   }
 
-  return highestBonusPoints;
+  return highestBonusPoints + getApiBonusMilestonePoints(faciCounts);
 }
 
 /**
  * Return a per-milestone bonus breakdown while applying the highest-only rule.
+ * `bonusMilestone` remains separate from the standard milestone map.
  */
 export function calculateMilestoneBonusBreakdown(
   faciCounts: FacilitatorCounts | null | undefined,
@@ -201,6 +218,7 @@ export function calculateMilestoneBonusBreakdown(
   if (!faciCounts) {
     return {
       milestones: { 1: 0, 2: 0, 3: 0, ultimate: 0 },
+      bonusMilestone: 0,
       total: 0,
       highestCompleted: 0,
     };
@@ -234,9 +252,12 @@ export function calculateMilestoneBonusBreakdown(
     }
   }
 
+  const bonusMilestone = getApiBonusMilestonePoints(faciCounts);
+
   return {
     milestones: milestoneBonus,
-    total: highestBonusPoints,
+    bonusMilestone,
+    total: highestBonusPoints + bonusMilestone,
     highestCompleted: highestCompletedMilestone,
   };
 }

--- a/tests/services/facilitatorService.test.ts
+++ b/tests/services/facilitatorService.test.ts
@@ -55,6 +55,26 @@ describe("calculateFacilitatorBonus", () => {
     expect(calculateFacilitatorBonus(null)).toBe(0);
   });
 
+  it("adds the API-calculated Bonus Milestone separately", () => {
+    expect(
+      calculateFacilitatorBonus({
+        faciGame: 6,
+        faciSkill: 18,
+        bonusMilestonePoints: 10,
+      }),
+    ).toBe(15);
+  });
+
+  it("uses whatever Bonus Milestone amount the API returns", () => {
+    expect(
+      calculateFacilitatorBonus({
+        faciGame: 6,
+        faciSkill: 18,
+        bonusMilestonePoints: 20,
+      }),
+    ).toBe(25);
+  });
+
   it("returns 0 when no milestone is completed", () => {
     expect(
       calculateFacilitatorBonus({
@@ -141,6 +161,7 @@ describe("calculateMilestoneBonusBreakdown", () => {
   it("returns zero breakdown for null/undefined", () => {
     const result = calculateMilestoneBonusBreakdown(null);
     expect(result.total).toBe(0);
+    expect(result.bonusMilestone).toBe(0);
     expect(result.highestCompleted).toBe(0);
     expect(result.milestones["1"]).toBe(0);
   });
@@ -155,10 +176,26 @@ describe("calculateMilestoneBonusBreakdown", () => {
 
     expect(result.highestCompleted).toBe(1);
     expect(result.total).toBe(5);
+    expect(result.bonusMilestone).toBe(0);
     expect(result.milestones["1"]).toBe(5);
     expect(result.milestones["2"]).toBe(0);
     expect(result.milestones["3"]).toBe(0);
     expect(result.milestones.ultimate).toBe(0);
+  });
+
+  it("keeps the API Bonus Milestone outside the standard milestone map", () => {
+    const result = calculateMilestoneBonusBreakdown({
+      faciGame: 6,
+      faciTrivia: 0,
+      faciSkill: 18,
+      faciCompletion: 0,
+      bonusMilestonePoints: 10,
+    });
+
+    expect(result.highestCompleted).toBe(1);
+    expect(result.milestones["1"]).toBe(5);
+    expect(result.bonusMilestone).toBe(10);
+    expect(result.total).toBe(15);
   });
 
   it("returns correct breakdown for ultimate milestone", () => {
@@ -176,12 +213,14 @@ describe("calculateMilestoneBonusBreakdown", () => {
 });
 
 describe("API-provided Facilitator rules", () => {
-  it("reads the backend-calculated bonus directly when present", () => {
+  it("reads only the standard milestone bonus from API metadata", () => {
     expect(getFacilitatorBonusFromApi({ estimatedBonusPoints: 5 })).toBe(5);
     expect(
       getFacilitatorBonusFromApi({
         estimatedBonusPoints: 5,
         milestoneBonusPoints: 15,
+        bonusMilestoneAvailablePoints: 10,
+        bonusMilestonePoints: 10,
       }),
     ).toBe(15);
     expect(getFacilitatorBonusFromApi()).toBeNull();

--- a/tests/utils/arcadeRequestSignature.test.ts
+++ b/tests/utils/arcadeRequestSignature.test.ts
@@ -1,9 +1,19 @@
 import { webcrypto } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { isBonusMilestoneCompletedMock } = vi.hoisted(() => ({
+  isBonusMilestoneCompletedMock: vi.fn(),
+}));
+
+vi.mock("../../services/bonusMilestoneService", () => ({
+  isBonusMilestoneCompleted: isBonusMilestoneCompletedMock,
+}));
+
 import { buildArcadeSignatureHeaders } from "../../utils/arcadeRequestSignature";
 
 describe("buildArcadeSignatureHeaders", () => {
   beforeEach(() => {
+    isBonusMilestoneCompletedMock.mockResolvedValue(false);
     vi.stubGlobal("crypto", webcrypto as unknown as Crypto);
     vi.stubGlobal("browser", {
       runtime: {
@@ -34,6 +44,7 @@ describe("buildArcadeSignatureHeaders", () => {
       ),
     ).resolves.toEqual({});
     expect(payload.extensionVersion).toBe("1.3.1");
+    expect(payload.facilitator).toEqual({ bonusMilestoneCompleted: false });
   });
 
   it("does not block Arcade v3 when only one signing credential is present", async () => {
@@ -60,7 +71,7 @@ describe("buildArcadeSignatureHeaders", () => {
     ).rejects.toThrow(/requires the \/api\/v3\/arcade endpoint/i);
   });
 
-  it("signs the manifest version in the body and exposes it as a header", async () => {
+  it("signs only the Bonus Milestone self-report flag with the manifest version", async () => {
     const payload: Record<string, unknown> = {
       url: "https://www.skills.google/public_profiles/abc123",
       profileId: "abc123",
@@ -72,6 +83,8 @@ describe("buildArcadeSignatureHeaders", () => {
     );
 
     expect(payload.extensionVersion).toBe("1.3.1");
+    expect(payload.facilitator).toEqual({ bonusMilestoneCompleted: false });
+    expect(payload.facilitator).not.toHaveProperty("participating");
     expect(headers).toEqual(
       expect.objectContaining({
         "X-Arcade-Key": "release-client-key",
@@ -81,6 +94,20 @@ describe("buildArcadeSignatureHeaders", () => {
         "X-Arcade-Signature": expect.stringMatching(/^[a-f0-9]{64}$/),
       }),
     );
+  });
+
+  it("sends true when the user has manually confirmed Bonus Milestone", async () => {
+    isBonusMilestoneCompletedMock.mockResolvedValue(true);
+    const payload: Record<string, unknown> = {
+      url: "https://www.skills.google/public_profiles/abc123",
+    };
+
+    await buildArcadeSignatureHeaders(
+      "https://private-api.example.test/api/v3/arcade",
+      payload,
+    );
+
+    expect(payload.facilitator).toEqual({ bonusMilestoneCompleted: true });
   });
 
   it("produces the same signature with or without a trailing endpoint slash", async () => {

--- a/types/popup.ts
+++ b/types/popup.ts
@@ -40,6 +40,10 @@ export interface FacilitatorApiMetadata {
   baseArcadePoints?: number;
   pointsAlreadyIncludedInArcadeTotal?: number;
   estimatedFacilitatorPoints?: number;
+  bonusMilestoneEnabled?: boolean;
+  bonusMilestoneConfirmation?: string;
+  bonusMilestoneAvailablePoints?: number;
+  bonusMilestoneCompleted?: boolean;
   bonusMilestonePoints?: number | null;
   bonusMilestoneStatus?: string;
   milestonePolicy?: string;
@@ -65,8 +69,9 @@ export interface ArcadeData {
     faciCompletion?: number;
     completedFaciCount?: number;
     completedFaciSkillCount?: number;
+    bonusMilestonePoints?: number;
   };
-  // Canonical Arcade v2 Facilitator contract.
+  // Canonical Arcade v2/v3 Facilitator contract.
   facilitator?: FacilitatorApiMetadata;
   // Deprecated legacy shape retained only so previously stored responses can
   // still be read safely. Current network requests do not consume this field.

--- a/utils/arcadeRequestSignature.ts
+++ b/utils/arcadeRequestSignature.ts
@@ -1,3 +1,5 @@
+import { isBonusMilestoneCompleted } from "../services/bonusMilestoneService";
+
 const encoder = new TextEncoder();
 
 /** Convert an ArrayBuffer into a lowercase hexadecimal string. */
@@ -85,9 +87,9 @@ function getCanonicalPathname(endpoint: string): string {
 }
 
 /**
- * Add the extension version to the Arcade v3 body and sign the request when
- * both client credentials are available. During rollout, missing credentials
- * intentionally produce an unsigned v3 request instead of blocking the fetch.
+ * Add the extension version and self-reported Bonus Milestone completion flag
+ * before signing. The API owns season availability and point values; the client
+ * sends only whether the user manually confirmed completion.
  */
 export async function buildArcadeSignatureHeaders(
   endpoint: string,
@@ -99,7 +101,14 @@ export async function buildArcadeSignatureHeaders(
 
   const extensionVersion = getExtensionVersion();
   if (body && typeof body === "object" && !Array.isArray(body)) {
-    (body as Record<string, unknown>).extensionVersion = extensionVersion;
+    const record = body as Record<string, unknown>;
+    const profileUrl = typeof record.url === "string" ? record.url : "";
+    if (profileUrl) {
+      record.facilitator = {
+        bonusMilestoneCompleted: await isBonusMilestoneCompleted(profileUrl),
+      };
+    }
+    record.extensionVersion = extensionVersion;
   }
 
   const clientKey = String(import.meta.env.WXT_ARCADE_CLIENT_KEY || "").trim();

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -3,6 +3,7 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react-swc";
 import type { Plugin } from "vite";
 
+/** Inject popup-only bootstrap scripts and compact-mode CSS before app startup. */
 function popupSizeBootstrapPlugin(): Plugin {
   return {
     name: "eplus-popup-size-bootstrap",
@@ -44,6 +45,14 @@ function popupSizeBootstrapPlugin(): Plugin {
               attrs: {
                 type: "module",
                 src: "/entrypoints/popup/compactModeSync.ts",
+              },
+            },
+            {
+              tag: "script",
+              injectTo: "head",
+              attrs: {
+                type: "module",
+                src: "/entrypoints/popup/bonusMilestoneControl.tsx",
               },
             },
           ],


### PR DESCRIPTION
Recreated from #217 on top of `dev` to avoid bringing unrelated `main` history into the branch.

### Changes
- Persist Bonus Milestone completion per Skills Boost profile.
- Send only `facilitator.bonusMilestoneCompleted` in the signed Arcade v3 request.
- Use API-owned Bonus Milestone availability/points.
- Render the control as a popup React component without service-side DOM observers.
- Preserve the existing `dev` Arcade v3 success-response handling from #214.

Supersedes #217 for the `dev` integration path.